### PR TITLE
Fix #12: Replace Tailwind tokens with Figma variable definitions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=DM+Serif+Display:ital@0;1&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=DM+Serif+Display:ital@0;1&family=DM+Serif+Text:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -131,23 +131,23 @@ body {
   }
 
   .paragraph-xl {
-    @apply type-xl font-normal font-sans;
+    @apply type-xl font-regular font-sans;
   }
 
   .paragraph-lg {
-    @apply type-lg font-normal font-sans;
+    @apply type-lg font-regular font-sans;
   }
 
   .paragraph-md {
-    @apply type-md font-normal font-sans;
+    @apply type-md font-regular font-sans;
   }
 
     .paragraph-base {
-    @apply type-base font-normal font-sans;
+    @apply type-base font-regular font-sans;
   }
 
   .paragraph-sm {
-    @apply type-sm font-normal font-sans;
+    @apply type-sm font-regular font-sans;
   }
 
   /**
@@ -156,19 +156,19 @@ body {
    */
 
      .quote-2xl {
-    @apply type-2xl font-normal font-sans italic;
+    @apply type-2xl font-regular font-sans italic;
   }
 
   .quote-xl {
-    @apply type-xl font-normal font-sans italic;
+    @apply type-xl font-regular font-sans italic;
   }
 
   .quote-lg {
-    @apply type-lg font-normal font-serif italic;
+    @apply type-lg font-regular font-serif italic;
   }
 
   .quote-md {
-    @apply type-md font-normal font-serif italic;
+    @apply type-md font-regular font-serif italic;
   }
 
   /**
@@ -177,11 +177,11 @@ body {
    */
 
   .code-inline {
-    @apply type-base font-normal font-mono;
+    @apply type-base font-regular font-mono;
   }
 
   .code-block {
-    @apply type-base font-normal font-mono;
+    @apply type-base font-regular font-mono;
     line-height: 1.75;
   }
 
@@ -191,14 +191,14 @@ body {
    */
 
   .caption {
-    @apply type-sm font-normal font-sans;
+    @apply type-sm font-regular font-sans;
   }
 }
 
 @layer utilities {
   /* Text selection */
   ::selection {
-    @apply bg-bones-yellow text-bones-black;
+    @apply bg-yellow text-black;
   }
 
   /* Prevent orphans in headings (last word alone on a line) */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,5 @@
-import type { Config } from 'tailwindcss';
 import typography from '@tailwindcss/typography';
+import type { Config } from 'tailwindcss';
 import fluidType from './plugins/fluidType';
 
 export default {
@@ -80,14 +80,12 @@ export default {
       'white-83': '#ffffffd4',
       'white-90': '#ffffffe5',
     },
-
     fontFamily: {
       display: ['DM Serif Display', 'serif'],
       mono: ['DM Mono', 'monospace'],
       sans: ['DM Sans', 'sans-serif'],
       serif: ['DM Serif Text', 'serif'],
     },
-
     fontWeight: {
       thin: '100',
       extralight: '200',
@@ -99,7 +97,6 @@ export default {
       extrabold: '800',
       black: '900',
     },
-
     spacing: {
       '0': '0px',
       '1': '1px',
@@ -121,7 +118,6 @@ export default {
       '96': '96px',
       '128': '128px',
     },
-
     borderRadius: {
       sharp: '0px',
       softest: '2px',


### PR DESCRIPTION
## Summary

- Replace all `bones-`-prefixed colour tokens with bare Figma variable names across `tailwind.config.ts` and `src/index.css`
- Replace `font-normal` with `font-regular` in typography utility classes
- Add DM Serif Text font import to match Figma type system

## Test plan

- [ ] `npm run build` succeeds with no errors
- [ ] Typography and colour tokens resolve correctly in the browser
- [ ] No visual regressions on existing pages

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)