### PR TITLE
Feat #23: Rebuild WorkPage as ResumePage using id.sifa collections

### DIFF
--- a/src/components/BadgeLanguage/BadgeLanguage.constants.ts
+++ b/src/components/BadgeLanguage/BadgeLanguage.constants.ts
@@ -1,0 +1,16 @@
+export const PROFICIENCY_LABELS: Record<string, string> = {
+  native: 'Native',
+  full_professional: 'Full Professional',
+  professional_working: 'Professional Working',
+  limited_working: 'Limited Working',
+  elementary: 'Elementary',
+};
+
+export function formatProficiency(proficiency: string): string {
+  return (
+    PROFICIENCY_LABELS[proficiency] ??
+    proficiency
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}

--- a/src/components/BadgeLanguage/BadgeLanguage.styles.ts
+++ b/src/components/BadgeLanguage/BadgeLanguage.styles.ts
@@ -1,0 +1,9 @@
+export const wrapper =
+  'bg-black-10 flex flex-col gap-0 items-start justify-center ' +
+  'px-16 py-8 whitespace-nowrap';
+
+export const languageStyles =
+  'font-sans font-black text-base leading-[28px] text-black';
+
+export const proficiencyStyles =
+  'font-sans font-medium text-base leading-[28px] text-dimgray';

--- a/src/components/BadgeLanguage/BadgeLanguage.tsx
+++ b/src/components/BadgeLanguage/BadgeLanguage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { formatProficiency } from './BadgeLanguage.constants';
+import * as styles from './BadgeLanguage.styles';
+import type { BadgeLanguageProps } from './BadgeLanguage.types';
+
+export const BadgeLanguage: React.FC<BadgeLanguageProps> = ({
+  language,
+  proficiency,
+}) => {
+  return (
+    <div className={styles.wrapper}>
+      <p className={styles.languageStyles}>{language}</p>
+      <p className={styles.proficiencyStyles}>{formatProficiency(proficiency)}</p>
+    </div>
+  );
+};

--- a/src/components/BadgeLanguage/BadgeLanguage.types.ts
+++ b/src/components/BadgeLanguage/BadgeLanguage.types.ts
@@ -1,0 +1,4 @@
+export interface BadgeLanguageProps {
+  language: string;
+  proficiency: string;
+}

--- a/src/components/CardPosition/CardPosition.constants.ts
+++ b/src/components/CardPosition/CardPosition.constants.ts
@@ -1,0 +1,4 @@
+export const COL_SPAN: Record<'full' | '2/3', string> = {
+  full: 'col-span-3',
+  '2/3': 'col-span-3 lg:col-span-2',
+};

--- a/src/components/CardPosition/CardPosition.styles.ts
+++ b/src/components/CardPosition/CardPosition.styles.ts
@@ -1,0 +1,32 @@
+export const cardWrapper =
+  'flex flex-col gap-16 items-start w-full';
+
+export const metaRow =
+  'flex items-start justify-between w-full';
+
+export const metaLeft =
+  'flex gap-4 items-start font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
+
+export const metaRight =
+  'flex gap-16 items-center';
+
+export const dateRow =
+  'flex gap-1 items-center font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
+
+export const currentBadge =
+  'bg-yellow px-8 font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
+
+export const titleStyles =
+  'font-sans font-black text-[24px] leading-[32px] text-black w-full overflow-hidden text-ellipsis';
+
+export const descriptionStyles =
+  'font-sans font-medium text-base leading-[28px] text-black w-full overflow-hidden text-ellipsis';
+
+export const locationRow =
+  'flex gap-16 items-start';
+
+export const locationText =
+  'flex gap-1 items-start font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
+
+export const remoteBadge =
+  'bg-black-10 px-8 font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';

--- a/src/components/CardPosition/CardPosition.tsx
+++ b/src/components/CardPosition/CardPosition.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import * as styles from './CardPosition.styles';
+import type { CardPositionProps } from './CardPosition.types';
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  if (isNaN(date.getTime())) return dateString;
+  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+}
+
+export const CardPosition: React.FC<CardPositionProps> = ({
+  company,
+  title,
+  description,
+  employmentType,
+  startedAt,
+  endedAt,
+  location,
+  remote,
+}) => {
+  const isCurrent = !endedAt;
+  const formattedStart = startedAt ? formatDate(startedAt) : null;
+  const formattedEnd = endedAt ? formatDate(endedAt) : null;
+
+  return (
+    <div className={styles.cardWrapper}>
+
+
+      {/* Title */}
+      <p className={styles.titleStyles}>{title}</p>
+
+      {/* Meta row: company · type on left, badge + dates on right */}
+      <div className={styles.metaRow}>
+        <div className={styles.metaLeft}>
+          <span>{company}</span>
+          {employmentType && (
+            <>
+              <span>·</span>
+              <span>{employmentType}</span>
+            </>
+          )}
+        </div>
+        <div className={styles.metaRight}>
+          {isCurrent && (
+            <span className={styles.currentBadge}>Current</span>
+          )}
+          {formattedStart && (
+            <div className={styles.dateRow}>
+              <span>{formattedStart}</span>
+              <span>–</span>
+              <span>{formattedEnd ?? 'Date'}</span>
+            </div>
+          )}
+        </div>
+      </div>
+      {/* Description */}
+      {description && (
+        <p className={styles.descriptionStyles}>{description}</p>
+      )}
+
+      {/* Location row */}
+      {(location || remote) && (
+        <div className={styles.locationRow}>
+          {location && (location.city || location.country) && (
+            <div className={styles.locationText}>
+              {location.city && <span>{location.city}</span>}
+              {location.city && location.country && <span>,</span>}
+              {location.country && <span>{location.country}</span>}
+            </div>
+          )}
+          {remote && (
+            <span className={styles.remoteBadge}>Remote</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/CardPosition/CardPosition.types.ts
+++ b/src/components/CardPosition/CardPosition.types.ts
@@ -1,0 +1,17 @@
+export interface CardPositionLocation {
+  city?: string;
+  region?: string;
+  country?: string;
+  countryCode?: string;
+}
+
+export interface CardPositionProps {
+  company: string;
+  title: string;
+  description?: string;
+  employmentType?: string;
+  startedAt?: string;
+  endedAt?: string;
+  location?: CardPositionLocation;
+  remote?: boolean;
+}

--- a/src/components/CardSkillCategory/CardSkillCategory.constants.ts
+++ b/src/components/CardSkillCategory/CardSkillCategory.constants.ts
@@ -1,0 +1,13 @@
+export const CATEGORY_LABELS: Record<string, string> = {
+  creative: 'Creative',
+  business: 'Business',
+  interpersonal: 'Interpersonal',
+  other: 'Other',
+};
+
+export function formatCategory(category: string): string {
+  return (
+    CATEGORY_LABELS[category] ??
+    category.replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}

--- a/src/components/CardSkillCategory/CardSkillCategory.styles.ts
+++ b/src/components/CardSkillCategory/CardSkillCategory.styles.ts
@@ -1,0 +1,11 @@
+export const cardWrapper = 'flex flex-col gap-8 items-start w-full';
+
+export const categoryLabel =
+  'font-sans font-black text-base leading-[28px] text-black w-full';
+
+export const badgeRow =
+  'flex flex-wrap gap-8 items-center w-full';
+
+export const badge =
+  'bg-black-10 px-8 font-sans font-medium text-base leading-[28px] ' +
+  'text-black whitespace-nowrap';

--- a/src/components/CardSkillCategory/CardSkillCategory.tsx
+++ b/src/components/CardSkillCategory/CardSkillCategory.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { formatCategory } from './CardSkillCategory.constants';
+import * as styles from './CardSkillCategory.styles';
+import type { CardSkillCategoryProps } from './CardSkillCategory.types';
+
+export const CardSkillCategory: React.FC<CardSkillCategoryProps> = ({
+  category,
+  skills,
+}) => {
+  return (
+    <div className={styles.cardWrapper}>
+      <p className={styles.categoryLabel}>{formatCategory(category)}</p>
+      <div className={styles.badgeRow}>
+        {skills.map((skill) => (
+          <span key={skill} className={styles.badge}>
+            {skill}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/CardSkillCategory/CardSkillCategory.types.ts
+++ b/src/components/CardSkillCategory/CardSkillCategory.types.ts
@@ -1,0 +1,4 @@
+export interface CardSkillCategoryProps {
+  category: string;
+  skills: string[];
+}

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Link } from '@/components/Link/Link';
+import React from 'react';
 import { NAV_LINKS } from './PageHeader.constants';
 import {
   exitRow,
@@ -12,22 +12,12 @@ import {
 } from './PageHeader.styles';
 import type { PageHeaderProps } from './PageHeader.types';
 
-export const PageHeader: React.FC<PageHeaderProps> = ({
-  pageTitle,
-  overline,
-  className,
-}) => {
+export const PageHeader: React.FC<PageHeaderProps> = ({ pageTitle, overline, className }) => {
   return (
     <header className={getWrapperStyles(className)}>
       {/* Mobile only: EXIT link sits above the title */}
       <div className={exitRow}>
-        <Link
-          href='/'
-          label='EXIT'
-          usecase='default'
-          hasLeftIcon={true}
-          hasRightIcon={false}
-        />
+        <Link href="/" label="Back to Home" usecase="default" hasLeftIcon={true} hasRightIcon={false} />
       </div>
 
       {/* Title block: order-2 mobile → order-1 desktop */}
@@ -44,7 +34,7 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
               key={link.label}
               href={link.href}
               label={link.label}
-              usecase='default'
+              usecase="default"
               hasLeftIcon={false}
               hasRightIcon={false}
             />

--- a/src/components/SectionPosition/SectionPosition.constants.ts
+++ b/src/components/SectionPosition/SectionPosition.constants.ts
@@ -1,0 +1,4 @@
+export const COL_SPAN: Record<'full' | '2/3', string> = {
+  full: 'col-span-3',
+  '2/3': 'col-span-3 lg:col-span-2',
+};

--- a/src/components/SectionPosition/SectionPosition.styles.ts
+++ b/src/components/SectionPosition/SectionPosition.styles.ts
@@ -1,0 +1,10 @@
+import { mergeClasses } from '@/lib/utils/mergeClasses';
+import { COL_SPAN } from './SectionPosition.constants';
+
+export const gridWrapper = 'grid grid-cols-3 2xl:grid-cols-4 gap-x-32 gap-y-32 w-full';
+
+const columnBase = 'flex flex-col gap-16 items-start justify-self-stretch self-start';
+
+export function getColStyles(usecase: 'full' | '2/3'): string {
+  return mergeClasses(columnBase, COL_SPAN[usecase]);
+}

--- a/src/components/SectionPosition/SectionPosition.tsx
+++ b/src/components/SectionPosition/SectionPosition.tsx
@@ -1,0 +1,17 @@
+import { CardPosition } from '@/components/CardPosition/CardPosition';
+import React from 'react';
+import { getColStyles, gridWrapper } from './SectionPosition.styles';
+import type { SectionPositionProps } from './SectionPosition.types';
+
+export const SectionPosition: React.FC<SectionPositionProps> = ({
+  usecase = '2/3',
+  ...cardProps
+}) => {
+  return (
+    <div className={gridWrapper}>
+      <div className={getColStyles(usecase)}>
+        <CardPosition {...cardProps} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/SectionPosition/SectionPosition.types.ts
+++ b/src/components/SectionPosition/SectionPosition.types.ts
@@ -1,0 +1,5 @@
+import type { CardPositionProps } from '@/components/CardPosition/CardPosition.types';
+
+export interface SectionPositionProps extends CardPositionProps {
+  usecase?: 'full' | '2/3';
+}

--- a/src/components/SectionSkillCategory/SectionSkillCategory.constants.ts
+++ b/src/components/SectionSkillCategory/SectionSkillCategory.constants.ts
@@ -1,0 +1,4 @@
+export const COL_SPAN: Record<'full' | '2/3', string> = {
+  full: 'col-span-3',
+  '2/3': 'col-span-3 lg:col-span-2',
+};

--- a/src/components/SectionSkillCategory/SectionSkillCategory.styles.ts
+++ b/src/components/SectionSkillCategory/SectionSkillCategory.styles.ts
@@ -1,0 +1,12 @@
+import { mergeClasses } from '@/lib/utils/mergeClasses';
+import { COL_SPAN } from './SectionSkillCategory.constants';
+
+export const gridWrapper =
+  'grid grid-cols-3 2xl:grid-cols-4 gap-x-32 gap-y-32 w-full';
+
+const columnBase =
+  'flex flex-col gap-16 items-start justify-self-stretch self-start';
+
+export function getColStyles(usecase: 'full' | '2/3'): string {
+  return mergeClasses(columnBase, COL_SPAN[usecase]);
+}

--- a/src/components/SectionSkillCategory/SectionSkillCategory.tsx
+++ b/src/components/SectionSkillCategory/SectionSkillCategory.tsx
@@ -1,0 +1,17 @@
+import { CardSkillCategory } from '@/components/CardSkillCategory/CardSkillCategory';
+import React from 'react';
+import { getColStyles, gridWrapper } from './SectionSkillCategory.styles';
+import type { SectionSkillCategoryProps } from './SectionSkillCategory.types';
+
+export const SectionSkillCategory: React.FC<SectionSkillCategoryProps> = ({
+  usecase = '2/3',
+  ...cardProps
+}) => {
+  return (
+    <div className={gridWrapper}>
+      <div className={getColStyles(usecase)}>
+        <CardSkillCategory {...cardProps} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/SectionSkillCategory/SectionSkillCategory.types.ts
+++ b/src/components/SectionSkillCategory/SectionSkillCategory.types.ts
@@ -1,0 +1,5 @@
+import type { CardSkillCategoryProps } from '@/components/CardSkillCategory/CardSkillCategory.types';
+
+export interface SectionSkillCategoryProps extends CardSkillCategoryProps {
+  usecase?: 'full' | '2/3';
+}

--- a/src/config/atproto/getConfig.ts
+++ b/src/config/atproto/getConfig.ts
@@ -8,7 +8,7 @@ export const ATPROTO_CONFIG = {
   DID: 'did:plc:s2rczyxit2v5vzedxqs326ri',
 
   /** PDS (Personal Data Server) URL */
-  PDS_URL: 'https://rooter.us-west.host.bsky.network',
+  PDS_URL: 'https://eurosky.social',
 
   /** Bluesky CDN URL for blob storage (images, etc.) */
   CDN_URL: 'https://cdn.bsky.app',
@@ -20,4 +20,7 @@ export const ATPROTO_CONFIG = {
 export const ATPROTO_COLLECTIONS = {
   PUBLICATION: 'pub.leaflet.publication',
   DOCUMENT: 'pub.leaflet.document',
+  POSITION: 'id.sifa.profile.position',
+  SKILL: 'id.sifa.profile.skill',
+  LANGUAGE: 'id.sifa.profile.language',
 } as const;

--- a/src/hooks/atproto/index.ts
+++ b/src/hooks/atproto/index.ts
@@ -7,3 +7,7 @@ export type { Document, Publication } from './useLeaflet';
 export { useProtopro } from './useProtopro';
 export type { Profile } from './useProtopro';
 export { useRecords } from './useRecords';
+export { useSifaLanguages } from './useSifaLanguages';
+export { useSifaPositions } from './useSifaPositions';
+export { useSifaSkills } from './useSifaSkills';
+export type { SkillsByCategory } from './useSifaSkills';

--- a/src/hooks/atproto/useSifaLanguages.ts
+++ b/src/hooks/atproto/useSifaLanguages.ts
@@ -1,0 +1,20 @@
+import { ATPROTO_COLLECTIONS } from '@/config/atproto';
+import type { SifaLanguageValue } from '@/types/atproto';
+import type { FetchResult } from '@/types/atproto';
+import { useRecords } from './useRecords';
+
+export function useSifaLanguages(): FetchResult<SifaLanguageValue[]> {
+  const { data: records, loading, error } = useRecords<SifaLanguageValue>(
+    ATPROTO_COLLECTIONS.LANGUAGE,
+  );
+
+  if (loading || error || !records) {
+    return { data: null, loading, error };
+  }
+
+  return {
+    data: records.map((r) => r.value),
+    loading: false,
+    error: null,
+  };
+}

--- a/src/hooks/atproto/useSifaPositions.ts
+++ b/src/hooks/atproto/useSifaPositions.ts
@@ -1,0 +1,36 @@
+import { ATPROTO_COLLECTIONS } from '@/config/atproto';
+import type { SifaPositionValue } from '@/types/atproto';
+import { useEffect, useState } from 'react';
+import type { FetchResult } from '@/types/atproto';
+import { useRecords } from './useRecords';
+
+export function useSifaPositions(): FetchResult<SifaPositionValue[]> {
+  const {
+    data: records,
+    loading,
+    error,
+  } = useRecords<SifaPositionValue>(ATPROTO_COLLECTIONS.POSITION);
+
+  const [data, setData] = useState<SifaPositionValue[] | null>(null);
+
+  useEffect(() => {
+    if (loading || error || !records) return;
+
+    const positions = records
+      .map((r) => r.value)
+      .sort((a, b) => {
+        // Current roles (no endedAt) first, then past roles newest-first
+        const aIsCurrent = !a.endedAt;
+        const bIsCurrent = !b.endedAt;
+        if (aIsCurrent && !bIsCurrent) return -1;
+        if (!aIsCurrent && bIsCurrent) return 1;
+        const dateA = new Date(a.endedAt ?? a.startedAt).getTime();
+        const dateB = new Date(b.endedAt ?? b.startedAt).getTime();
+        return dateB - dateA;
+      });
+
+    setData(positions);
+  }, [records, loading, error]);
+
+  return { data, loading, error };
+}

--- a/src/hooks/atproto/useSifaSkills.ts
+++ b/src/hooks/atproto/useSifaSkills.ts
@@ -1,0 +1,33 @@
+import { ATPROTO_COLLECTIONS } from '@/config/atproto';
+import type { SifaSkillValue } from '@/types/atproto';
+import type { FetchResult } from '@/types/atproto';
+import { useRecords } from './useRecords';
+
+export interface SkillsByCategory {
+  category: string;
+  skills: string[];
+}
+
+export function useSifaSkills(): FetchResult<SkillsByCategory[]> {
+  const { data: records, loading, error } = useRecords<SifaSkillValue>(
+    ATPROTO_COLLECTIONS.SKILL,
+  );
+
+  if (loading || error || !records) {
+    return { data: null, loading, error };
+  }
+
+  const grouped = new Map<string, string[]>();
+
+  for (const record of records) {
+    const category = record.value.category ?? 'other';
+    if (!grouped.has(category)) grouped.set(category, []);
+    grouped.get(category)!.push(record.value.name);
+  }
+
+  const data: SkillsByCategory[] = Array.from(grouped.entries()).map(
+    ([category, skills]) => ({ category, skills }),
+  );
+
+  return { data, loading: false, error: null };
+}

--- a/src/pages/WorkPage.tsx
+++ b/src/pages/WorkPage.tsx
@@ -1,130 +1,116 @@
-import { CardRole } from '@/components/CardRole/CardRole';
-import { Divider } from '@/components/Divider/Divider';
-import { Heading } from '@/components/Heading/Heading';
-import { Aside, Layout, Main } from '@/components/Layout/Layout';
-import { Link } from '@/components/Link/Link';
-import { Paragraph } from '@/components/Paragraph/Paragraph';
-import Section from '@/components/Section/Section';
-import TLDRProfile from '@/components/TLDRProfile/TLDRProfile';
-import { useProtopro } from '@/hooks/atproto';
+import { BadgeLanguage } from '@/components/BadgeLanguage/BadgeLanguage';
+import { PageFooter } from '@/components/PageFooter/PageFooter';
+import { PageHeader } from '@/components/PageHeader/PageHeader';
+import { SectionPosition } from '@/components/SectionPosition/SectionPosition';
+import { SectionSkillCategory } from '@/components/SectionSkillCategory/SectionSkillCategory';
+import { useSifaLanguages, useSifaPositions, useSifaSkills } from '@/hooks/atproto';
 import type { JSX } from 'react';
 import { Helmet } from 'react-helmet-async';
 
-/**
- * Work page component - displays CV/work history from AT Protocol PDS
- *
- * @returns JSX element with work page content
- */
+const JSON_LD = {
+  '@context': 'https://schema.org',
+  '@type': 'ProfilePage',
+  mainEntity: {
+    '@type': 'Person',
+    name: 'Barry Prendergast',
+    jobTitle: 'UX Strategist and Designer',
+    url: 'https://renderg.host/work',
+  },
+};
+
+const sectionLabel = 'font-sans font-semibold text-base leading-[24px] text-dimgray ' + 'tracking-[1px] uppercase';
+
 export default function WorkPage(): JSX.Element {
-  const { data: profile, loading, error } = useProtopro();
+  const { data: positions, loading: positionsLoading, error: positionsError } = useSifaPositions();
+  const { data: skillCategories, loading: skillsLoading, error: skillsError } = useSifaSkills();
+  const { data: languages, loading: languagesLoading, error: languagesError } = useSifaLanguages();
 
-  // Split jobs into current and past
-  const currentJobs = profile?.jobHistory.filter((job) => !job.endDate) || [];
-  const pastJobs =
-    profile?.jobHistory
-      .filter((job) => job.endDate)
-      .sort((a, b) => {
-        // Sort by end date, newest first
-        const dateA = a.endDate ? new Date(a.endDate).getTime() : 0;
-        const dateB = b.endDate ? new Date(b.endDate).getTime() : 0;
-        return dateB - dateA;
-      }) || [];
+  const currentPositions = positions?.filter((p) => !p.endedAt) ?? [];
+  const pastPositions = positions?.filter((p) => !!p.endedAt) ?? [];
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'ProfilePage',
-    mainEntity: {
-      '@type': 'Person',
-      name: 'Barry Prendergast',
-      jobTitle: currentJobs[0]?.position || 'Product Designer',
-      description: 'Independent product designer and strategist',
-      url: 'https://renderg.host/work',
-    },
-  };
+  const loading = positionsLoading || skillsLoading || languagesLoading;
+  const error = positionsError ?? skillsError ?? languagesError;
 
   return (
     <>
       <Helmet>
-        <title>Work | Barry Prendergast</title>
+        <title>Resume | Barry Prendergast</title>
         <meta
           name="description"
           content="Independent product designer helping organisations deliver better products through clear thinking, practical design, and meaningful collaboration."
         />
-        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }} />
       </Helmet>
 
-      <Layout theme="default">
-        <Main>
-          <div className="flex flex-col gap-16">
-            {/* Heading */}
-            <Section>
-              <Heading level={2} size="base">
-                work / <Link href="/">renderg.host</Link>
-              </Heading>
-            </Section>
+      <div className="flex flex-col items-center w-full bg-whitesmoke">
+        <PageHeader pageTitle="My Resume" />
 
-            {/* Loading/Error States */}
-            {loading && (
-              <Section>
-                <Paragraph size="2xl">Loading profile...</Paragraph>
-              </Section>
-            )}
+        <div className="flex flex-col gap-32 items-start w-full max-w-[1920px] px-24 pt-32 pb-128">
+          {loading && <p className="font-sans font-medium text-base leading-[28px] text-black">Loading...</p>}
 
-            {error && (
-              <Section>
-                <Paragraph size="2xl">Error loading profile: {error}</Paragraph>
-              </Section>
-            )}
+          {error && (
+            <p className="font-sans font-medium text-base leading-[28px] text-black">Error loading data: {error}</p>
+          )}
 
-            {/* Current Work Section */}
-            {!loading && !error && currentJobs.length > 0 && (
-              <Section>
-                <Heading level={2} size="lg">
-                  Current roles
-                </Heading>
+          {!loading && !error && currentPositions.length > 0 && (
+            <>
+              <p className={sectionLabel}>Current Roles</p>
+              {currentPositions.map((position, index) => (
+                <SectionPosition
+                  key={`current-${position.company}-${index}`}
+                  company={position.company}
+                  title={position.title}
+                  description={position.description}
+                  employmentType={position.employmentType}
+                  startedAt={position.startedAt}
+                  endedAt={position.endedAt}
+                  location={position.location}
+                />
+              ))}
+            </>
+          )}
 
-                <div className="grid grid-cols-1 border-2 border-bones-black-20 dark:border-bones-white-20">
-                  {currentJobs.map((job, index) => (
-                    <>
-                      <CardRole key={`current-${job.company}-${index}`} role={job} />
-                      {index < currentJobs.length - 1 && <Divider />}
-                    </>
-                  ))}
-                </div>
-              </Section>
-            )}
+          {!loading && !error && pastPositions.length > 0 && (
+            <>
+              <p className={sectionLabel}>Previous Roles</p>
+              {pastPositions.map((position, index) => (
+                <SectionPosition
+                  key={`past-${position.company}-${index}`}
+                  company={position.company}
+                  title={position.title}
+                  description={position.description}
+                  employmentType={position.employmentType}
+                  startedAt={position.startedAt}
+                  endedAt={position.endedAt}
+                  location={position.location}
+                />
+              ))}
+            </>
+          )}
 
-            {/* Past Work Section */}
-            {!loading && !error && pastJobs.length > 0 && (
-              <Section>
-                <Heading level={2} size="lg">
-                  Previous roles
-                </Heading>
+          {!loading && !error && skillCategories && skillCategories.length > 0 && (
+            <>
+              <p className={sectionLabel}>Skills</p>
+              {skillCategories.map((group) => (
+                <SectionSkillCategory key={group.category} category={group.category} skills={group.skills} />
+              ))}
+            </>
+          )}
 
-                <div className="grid grid-cols-1 border-2 border-bones-black-20 dark:border-bones-white-20">
-                  {pastJobs.map((job, index) => (
-                    <>
-                      <CardRole key={`past-${job.company}-${index}`} role={job} />
-                      {index < pastJobs.length - 1 && <Divider />}
-                    </>
-                  ))}
-                </div>
-              </Section>
-            )}
+          {!loading && !error && languages && languages.length > 0 && (
+            <>
+              <p className={sectionLabel}>Languages</p>
+              <div className="flex gap-8 items-start flex-wrap">
+                {languages.map((lang) => (
+                  <BadgeLanguage key={lang.name} language={lang.name} proficiency={lang.proficiency} />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
 
-            {/* Exit */}
-            <Section>
-              <Paragraph size="md">
-                Return to <Link href="/">renderg.host</Link>
-              </Paragraph>
-            </Section>
-          </div>
-        </Main>
-
-        <Aside>
-          <TLDRProfile />
-        </Aside>
-      </Layout>
+        <PageFooter />
+      </div>
     </>
   );
 }

--- a/src/types/atproto/defineSifa.ts
+++ b/src/types/atproto/defineSifa.ts
@@ -1,0 +1,46 @@
+/**
+ * Sifa AT Protocol type definitions
+ * Types for id.sifa.profile.* collections
+ */
+
+export interface SifaSkillRef {
+  cid: string;
+  uri: string;
+}
+
+/**
+ * Value type for id.sifa.profile.position records
+ */
+export interface SifaLocation {
+  city?: string;
+  region?: string;
+  country?: string;
+  countryCode?: string;
+}
+
+export interface SifaSkillValue {
+  $type: 'id.sifa.profile.skill';
+  name: string;
+  category?: string;
+  createdAt: string;
+}
+
+export interface SifaLanguageValue {
+  $type: 'id.sifa.profile.language';
+  name: string;
+  proficiency: string;
+  createdAt: string;
+}
+
+export interface SifaPositionValue {
+  $type: 'id.sifa.profile.position';
+  company: string;
+  title: string;
+  description?: string;
+  employmentType?: string;
+  startedAt: string;
+  endedAt?: string;
+  location?: SifaLocation;
+  skills?: SifaSkillRef[];
+  isPrimary?: boolean;
+}

--- a/src/types/atproto/index.ts
+++ b/src/types/atproto/index.ts
@@ -15,3 +15,12 @@ export type {
   LanguageProficiency,
   ProfileValue,
 } from './defineProtopro';
+
+// Sifa types
+export type {
+  SifaLanguageValue,
+  SifaLocation,
+  SifaPositionValue,
+  SifaSkillRef,
+  SifaSkillValue,
+} from './defineSifa';


### PR DESCRIPTION
## Summary

- Replaced Protopro (`blue.protopro.job`) data source with `id.sifa.profile.position` collection
- Replaced `CardRole` with new `CardPosition` / `SectionPosition` components matching Figma
- Added `useSifaPositions`, `useSifaSkills`, `useSifaLanguages` hooks
- Added `SectionSkillCategory` / `CardSkillCategory` for grouped skill badges
- Added `BadgeLanguage` for language proficiency display
- Added `SifaPositionValue`, `SifaSkillValue`, `SifaLanguageValue` types
- Fixed PDS URL from `rooter.us-west.host.bsky.network` → `eurosky.social`
- All optional fields degrade gracefully — no errors if skills, location, etc. are absent

## Test plan
- [x] Tested locally with `npm run dev`
- [x] No new lint errors
- [x] Current roles show yellow "Current" badge and "Date" as end date
- [x] Past roles show formatted date range
- [x] Skills grouped by category with inline badges
- [x] Languages rendered as `BadgeLanguage` components

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)