### PR TITLE
Fix #27: WritingPage redesign and site.standard.document migration

### DIFF
--- a/src/components/CardArticle/CardArticle.styles.ts
+++ b/src/components/CardArticle/CardArticle.styles.ts
@@ -1,10 +1,26 @@
-export const cardWrapper = 'group relative flex flex-col h-full bg-bones-white dark:bg-bones-black';
-export const contentContainer = 'flex flex-col flex-grow gap-4 p-8 justify-between';
-export const coverImage = 'object-cover w-full h-full transition-transform group-hover:scale-105';
-export const coverImageContainer = 'relative aspect-[16/9] w-full overflow-hidden bg-neutral-100 dark:bg-neutral-700';
-export const date = 'text-neutral-600 dark:text-neutral-400';
-export const detailContainer = 'flex flex-col gap-4';
-export const metaContainer = 'flex items-center justify-between';
-export const publicationContainer = 'flex items-center gap-2';
-export const publicationIcon = 'h-8 w-8 object-contain';
-export const publicationName = 'font-medium text-neutral-900 dark:text-neutral-100';
+export const cardWrapper =
+  'flex gap-32 items-start p-24 w-full';
+
+export const coverImageContainer =
+  'aspect-[16/9] w-[301px] shrink-0 overflow-hidden bg-black-06';
+
+export const coverImage =
+  'object-cover w-full h-full';
+
+export const contentContainer =
+  'flex flex-col gap-16 flex-1 min-w-0 items-start';
+
+export const metaRow =
+  'flex gap-8 items-center';
+
+export const publicationAvatar =
+  'size-[28px] object-contain shrink-0';
+
+export const metaText =
+  'text-base font-medium leading-[28px] whitespace-nowrap text-black';
+
+export const title =
+  'text-[32px] font-black leading-[40px] text-black w-full';
+
+export const subtitle =
+  'text-base font-medium leading-[28px] text-black overflow-hidden text-ellipsis w-full';

--- a/src/components/CardArticle/CardArticle.tsx
+++ b/src/components/CardArticle/CardArticle.tsx
@@ -1,42 +1,57 @@
-import { Heading } from '@/components/Heading/Heading';
-import { Paragraph } from '@/components/Paragraph/Paragraph';
+import { Link } from '@/components/Link/Link';
 import React from 'react';
 import { DATE_FORMAT_OPTIONS } from './CardArticle.constants';
 import * as styles from './CardArticle.styles';
-import { CardArticleProps } from './CardArticle.types';
+import type { CardArticleProps } from './CardArticle.types';
 
 export const CardArticle: React.FC<CardArticleProps> = ({ article }) => {
-  const formattedDate = new Date(article.published).toLocaleDateString('en-US', DATE_FORMAT_OPTIONS);
+  const formattedDate = new Date(article.published).toLocaleDateString(
+    'en-US',
+    DATE_FORMAT_OPTIONS,
+  );
 
   return (
-    <a href={article.articleUrl} target="_blank" rel="noopener noreferrer" className={styles.cardWrapper}>
-      {/* Cover Image (if available) */}
-      {article.coverImage && (
-        <div className={styles.coverImageContainer}>
+    <div className={styles.cardWrapper}>
+      {/* Cover image */}
+      <div className={styles.coverImageContainer}>
+        {article.coverImage && (
           <img src={article.coverImage} alt="" className={styles.coverImage} />
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Content */}
       <div className={styles.contentContainer}>
-        <div className={styles.detailContainer}>
-          {/* Title */}
-          <Heading level={3} size="md">
-            {article.title}
-          </Heading>
+        {/* Meta row: publication avatar · name · date */}
+        <div className={styles.metaRow}>
+          {article.publicationIcon && (
+            <img
+              src={article.publicationIcon}
+              alt=""
+              className={styles.publicationAvatar}
+            />
+          )}
+          <span className={styles.metaText}>{article.publication}</span>
+          <span className={styles.metaText}>·</span>
+          <span className={styles.metaText}>{formattedDate}</span>
+        </div>
 
-          {/* Description */}
-          {article.subtitle && <Paragraph size="base">{article.subtitle}</Paragraph>}
-        </div>
-        {/* Publication Name (left) and Date (right) */}
-        <div className={styles.metaContainer}>
-          <div className={styles.publicationContainer}>
-            {article.publicationIcon && <img src={article.publicationIcon} alt="" className={styles.publicationIcon} />}
-            <span className={styles.publicationName}>{article.publication}</span>
-          </div>
-          <span className={styles.date}>{formattedDate}</span>
-        </div>
+        {/* Title */}
+        <p className={styles.title}>{article.title}</p>
+
+        {/* Subtitle */}
+        {article.subtitle && (
+          <p className={styles.subtitle}>{article.subtitle}</p>
+        )}
+
+        {/* Read link */}
+        <Link
+          href={article.articleUrl}
+          label="Read"
+          hasLeftIcon={false}
+          hasRightIcon={true}
+          iconRight="↗"
+        />
       </div>
-    </a>
+    </div>
   );
 };

--- a/src/components/SectionArticle/SectionArticle.constants.ts
+++ b/src/components/SectionArticle/SectionArticle.constants.ts
@@ -1,0 +1,4 @@
+export const COL_STYLES: Record<'full' | '2/3', string> = {
+  full: 'col-span-3 self-start',
+  '2/3': 'col-[1/span_2] self-stretch',
+};

--- a/src/components/SectionArticle/SectionArticle.styles.ts
+++ b/src/components/SectionArticle/SectionArticle.styles.ts
@@ -1,0 +1,12 @@
+import { mergeClasses } from '@/lib/utils/mergeClasses';
+import { COL_STYLES } from './SectionArticle.constants';
+
+export const gridWrapper =
+  'grid grid-cols-3 gap-x-32 gap-y-32 w-full';
+
+const columnBase =
+  'flex flex-col gap-0 items-start';
+
+export function getColStyles(usecase: 'full' | '2/3'): string {
+  return mergeClasses(columnBase, COL_STYLES[usecase]);
+}

--- a/src/components/SectionArticle/SectionArticle.tsx
+++ b/src/components/SectionArticle/SectionArticle.tsx
@@ -1,0 +1,17 @@
+import { CardArticle } from '@/components/CardArticle/CardArticle';
+import React from 'react';
+import { getColStyles, gridWrapper } from './SectionArticle.styles';
+import type { SectionArticleProps } from './SectionArticle.types';
+
+export const SectionArticle: React.FC<SectionArticleProps> = ({
+  usecase = '2/3',
+  ...cardProps
+}) => {
+  return (
+    <div className={gridWrapper}>
+      <div className={getColStyles(usecase)}>
+        <CardArticle {...cardProps} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/SectionArticle/SectionArticle.types.ts
+++ b/src/components/SectionArticle/SectionArticle.types.ts
@@ -1,0 +1,5 @@
+import type { CardArticleProps } from '@/components/CardArticle/CardArticle.types';
+
+export interface SectionArticleProps extends CardArticleProps {
+  usecase?: 'full' | '2/3';
+}

--- a/src/config/atproto/buildUrls.ts
+++ b/src/config/atproto/buildUrls.ts
@@ -13,3 +13,10 @@ export function buildRecordsUrl(collection: string, repo: string = ATPROTO_CONFI
 export function buildBlobUrl(blobRef: string, did: string = ATPROTO_CONFIG.DID): string {
   return `${ATPROTO_CONFIG.CDN_URL}/img/avatar/plain/${did}/${blobRef}@jpeg`;
 }
+
+/**
+ * Constructs the CDN URL for an article cover image
+ */
+export function buildCoverUrl(blobRef: string, did: string = ATPROTO_CONFIG.DID): string {
+  return `${ATPROTO_CONFIG.CDN_URL}/img/feed_thumbnail/plain/${did}/${blobRef}@jpeg`;
+}

--- a/src/config/atproto/getConfig.ts
+++ b/src/config/atproto/getConfig.ts
@@ -1,7 +1,4 @@
-/**
- * AT Protocol configuration
- * Centralized configuration for connecting to AT Protocol PDS
- */
+/** AT Protocol configuration Centralized configuration for connecting to AT Protocol PDS */
 
 export const ATPROTO_CONFIG = {
   /** Your DID (Decentralized Identifier) */
@@ -15,11 +12,23 @@ export const ATPROTO_CONFIG = {
 } as const;
 
 /**
- * Collection identifiers for AT Protocol records
+ * Allowlist of site.standard.publication rkeys whose documents are permitted to appear on the writing page. Any
+ * document whose publication rkey is not in this list is filtered out.
  */
+export const ALLOWED_PUBLICATION_RKEYS: ReadonlySet<string> = new Set([
+  '3lz3s33asuc2l',
+  '3lzdlebwri22i',
+  '3m2jpv5avx22n',
+  // '3m4di6yzkt22z', // Marginalia
+  '3mihld7aab22v',
+]);
+
+/** Collection identifiers for AT Protocol records */
 export const ATPROTO_COLLECTIONS = {
   PUBLICATION: 'pub.leaflet.publication',
   DOCUMENT: 'pub.leaflet.document',
+  STANDARD_PUBLICATION: 'site.standard.publication',
+  STANDARD_DOCUMENT: 'site.standard.document',
   POSITION: 'id.sifa.profile.position',
   SKILL: 'id.sifa.profile.skill',
   LANGUAGE: 'id.sifa.profile.language',

--- a/src/config/atproto/index.ts
+++ b/src/config/atproto/index.ts
@@ -2,5 +2,5 @@
  * AT Protocol configuration exports
  */
 
-export { ATPROTO_COLLECTIONS, ATPROTO_CONFIG } from './getConfig';
-export { buildBlobUrl, buildRecordsUrl } from './buildUrls';
+export { ALLOWED_PUBLICATION_RKEYS, ATPROTO_COLLECTIONS, ATPROTO_CONFIG } from './getConfig';
+export { buildBlobUrl, buildCoverUrl, buildRecordsUrl } from './buildUrls';

--- a/src/hooks/atproto/useLeaflet.ts
+++ b/src/hooks/atproto/useLeaflet.ts
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
-import { ATPROTO_COLLECTIONS, buildBlobUrl } from '@/config/atproto';
-import type { ATProtocolDocument, ATProtocolPublication, FetchResult } from '@/types/atproto';
+import { ALLOWED_PUBLICATION_RKEYS, ATPROTO_COLLECTIONS, buildBlobUrl, buildCoverUrl } from '@/config/atproto';
+import type {
+  ATProtocolStandardDocument,
+  ATProtocolStandardPublication,
+  FetchResult,
+} from '@/types/atproto';
 import { useRecords } from './useRecords';
 
 /**
@@ -22,15 +26,40 @@ export interface Document {
   slug: string;
   title: string;
   description?: string;
+  coverImage?: string;
   publishedAt: string;
   articleUrl: string;
   publication: Publication;
 }
 
 /**
- * Hook for fetching Leaflet publications and their associated documents
- * Fetches from pub.leaflet.publication and pub.leaflet.document collections
- * Automatically resolves publication references in documents
+ * Extracts the cover image URL from the first image block in a document's content.
+ * The cover image is the first pub.leaflet.blocks.image block encountered.
+ */
+function extractCoverImage(
+  doc: ATProtocolStandardDocument['value'],
+): string | undefined {
+  const pages = doc.content?.pages;
+  if (!pages) return undefined;
+
+  for (const page of pages) {
+    for (const entry of page.blocks ?? []) {
+      if (
+        entry.block.$type === 'pub.leaflet.blocks.image' &&
+        entry.block.image
+      ) {
+        return buildCoverUrl(entry.block.image.ref.$link);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Hook for fetching Standard site publications and their associated documents.
+ * Fetches from site.standard.publication and site.standard.document collections.
+ * Automatically resolves publication references in documents.
  *
  * @returns FetchResult with combined documents and publications data
  *
@@ -54,77 +83,93 @@ export function useLeaflet(): FetchResult<Document[]> {
     data: publicationsData,
     loading: publicationsLoading,
     error: publicationsError,
-  } = useRecords<ATProtocolPublication['value']>(ATPROTO_COLLECTIONS.PUBLICATION);
+  } = useRecords<ATProtocolStandardPublication['value']>(
+    ATPROTO_COLLECTIONS.STANDARD_PUBLICATION,
+  );
 
   const {
     data: documentsData,
     loading: documentsLoading,
     error: documentsError,
-  } = useRecords<ATProtocolDocument['value']>(ATPROTO_COLLECTIONS.DOCUMENT);
+  } = useRecords<ATProtocolStandardDocument['value']>(
+    ATPROTO_COLLECTIONS.STANDARD_DOCUMENT,
+  );
 
   const [data, setData] = useState<Document[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    // Wait for both fetches to complete
     if (publicationsLoading || documentsLoading) {
       setLoading(true);
       return;
     }
 
-    // Check for errors
     if (publicationsError || documentsError) {
       setError(publicationsError || documentsError);
       setLoading(false);
       return;
     }
 
-    // Check if we have data
     if (!publicationsData || !documentsData) {
       setLoading(false);
       return;
     }
 
     try {
-      // Create publication lookup map
+      // Build publication lookup by URI
       const publicationMap = new Map<string, Publication>();
       publicationsData.forEach((record) => {
-        const iconUrl = record.value.icon ? buildBlobUrl(record.value.icon.ref.$link) : undefined;
+        const iconUrl = record.value.icon
+          ? buildBlobUrl(record.value.icon.ref.$link)
+          : undefined;
 
         publicationMap.set(record.uri, {
           uri: record.uri,
           name: record.value.name,
-          basePath: record.value.base_path,
+          basePath: record.value.url,
           icon: iconUrl,
           description: record.value.description,
         });
       });
 
-      // Transform documents with resolved publication data
+      // Transform documents
       const documents: Document[] = documentsData
         .map((record) => {
-          const slug = record.uri.split('/').pop() || '';
-          const publication = publicationMap.get(record.value.publication);
+          const publication = publicationMap.get(record.value.site);
 
           if (!publication) {
             console.warn(`Publication not found for document: ${record.uri}`);
             return null;
           }
 
+          // path already includes a leading slash, e.g. "/3m75kss5jfs2z"
+          // basePath is the full URL (e.g. "https://blento.app/did:plc:...")
+          const slug = record.value.path.replace(/^\//, '');
+          const articleUrl = `${publication.basePath}${record.value.path}`;
+          const coverImage = extractCoverImage(record.value);
+
           return {
             uri: record.uri,
             slug,
             title: record.value.title,
             description: record.value.description,
-            publishedAt: record.value.publishedAt,
-            articleUrl: `https://${publication.basePath}/${slug}`,
+            coverImage,
+            publishedAt: record.value.publishedAt ?? record.uri,
+            articleUrl,
             publication,
           } as Document;
         })
-        .filter((doc): doc is Document => doc !== null)
-        // Sort by published date, newest first
-        .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+        .filter((doc): doc is Document => {
+          if (doc === null) return false;
+          const rkey = doc.publication.uri.split('/').pop() ?? '';
+          return ALLOWED_PUBLICATION_RKEYS.has(rkey);
+        })
+        .sort(
+          (a, b) =>
+            new Date(b.publishedAt).getTime() -
+            new Date(a.publishedAt).getTime(),
+        );
 
       setData(documents);
       setError(null);
@@ -134,7 +179,14 @@ export function useLeaflet(): FetchResult<Document[]> {
     } finally {
       setLoading(false);
     }
-  }, [publicationsData, documentsData, publicationsLoading, documentsLoading, publicationsError, documentsError]);
+  }, [
+    publicationsData,
+    documentsData,
+    publicationsLoading,
+    documentsLoading,
+    publicationsError,
+    documentsError,
+  ]);
 
   return { data, loading, error };
 }

--- a/src/pages/WritingPage.tsx
+++ b/src/pages/WritingPage.tsx
@@ -1,19 +1,10 @@
-import { CardArticle } from '@/components/CardArticle/CardArticle';
-import { Divider } from '@/components/Divider/Divider';
-import { Heading } from '@/components/Heading/Heading';
-import { Aside, Layout, Main } from '@/components/Layout/Layout';
-import { Link } from '@/components/Link/Link';
+import { PageFooter } from '@/components/PageFooter/PageFooter';
+import { PageHeader } from '@/components/PageHeader/PageHeader';
 import { Paragraph } from '@/components/Paragraph/Paragraph';
-import TLDRProfile from '@/components/TLDRProfile/TLDRProfile';
+import { SectionArticle } from '@/components/SectionArticle/SectionArticle';
 import { useLeaflet } from '@/hooks/atproto';
 import type { JSX } from 'react';
 import { Helmet } from 'react-helmet-async';
-
-/**
- * Writing page component - displays blog posts from AT Protocol PDS
- *
- * @returns JSX element with writing page content
- */
 
 export default function WritingPage(): JSX.Element {
   const { data: documents, loading, error } = useLeaflet();
@@ -22,7 +13,8 @@ export default function WritingPage(): JSX.Element {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
     name: 'Writing by Barry Prendergast',
-    description: 'Articles and writing on design strategy, product design, and design operations.',
+    description:
+      'Articles and writing on design strategy, product design, and design operations.',
     url: 'https://renderg.host/writing',
     author: {
       '@type': 'Person',
@@ -39,58 +31,48 @@ export default function WritingPage(): JSX.Element {
           name="description"
           content="Articles and writing on design strategy, product design, and design operations by Barry Prendergast."
         />
-        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
       </Helmet>
 
-      <Layout theme="default">
-        <Main>
-          <div className="flex flex-col gap-12">
-            <Heading level={2} size="md">
-              writing / <Link href="/">renderg.host</Link>
-            </Heading>
+      <div className="bg-whitesmoke min-h-screen flex flex-col">
+        <PageHeader pageTitle="My Writing" />
 
-            <Paragraph size="lg">Thoughts on design strategy, product design, and building better products.</Paragraph>
+        <main className="flex flex-col gap-32 items-start px-24 pt-32 pb-128 flex-1">
+          {loading && <Paragraph size="lg">Loading posts...</Paragraph>}
 
-            {loading && <Paragraph size="lg">Loading posts...</Paragraph>}
+          {error && (
+            <Paragraph size="lg">Error loading posts: {error}</Paragraph>
+          )}
 
-            {error && <Paragraph size="lg">Error loading posts: {error}</Paragraph>}
+          {!loading && !error && (!documents || documents.length === 0) && (
+            <Paragraph size="lg">No posts found.</Paragraph>
+          )}
 
-            {!loading && !error && (!documents || documents.length === 0) && (
-              <Paragraph size="lg">No posts found.</Paragraph>
-            )}
+          {!loading &&
+            !error &&
+            documents &&
+            documents.map((doc) => (
+              <SectionArticle
+                key={doc.uri}
+                usecase="2/3"
+                article={{
+                  title: doc.title,
+                  subtitle: doc.description || '',
+                  coverImage: doc.coverImage || '',
+                  articleUrl: doc.articleUrl,
+                  publication: doc.publication.name,
+                  publicationIcon: doc.publication.icon,
+                  published: doc.publishedAt,
+                }}
+              />
+            ))}
+        </main>
 
-            {!loading && !error && documents && documents.length > 0 && (
-              <div className="grid grid-cols-1 border-2 border-bones-black-20 dark:border-bones-white-20">
-                {documents.map((doc, index) => (
-                  <>
-                    <CardArticle
-                      key={doc.uri}
-                      article={{
-                        title: doc.title,
-                        subtitle: doc.description || '',
-                        coverImage: '',
-                        articleUrl: doc.articleUrl,
-                        publication: doc.publication.name,
-                        publicationIcon: doc.publication.icon,
-                        published: doc.publishedAt,
-                      }}
-                    />
-                    {index < documents.length - 1 && <Divider />}
-                  </>
-                ))}
-              </div>
-            )}
-
-            <Paragraph size="lg">
-              <Link href="/">← Back to Home</Link>
-            </Paragraph>
-          </div>
-        </Main>
-
-        <Aside>
-          <TLDRProfile />
-        </Aside>
-      </Layout>
+        <PageFooter />
+      </div>
     </>
   );
 }

--- a/src/types/atproto/defineStandard.ts
+++ b/src/types/atproto/defineStandard.ts
@@ -1,0 +1,73 @@
+/**
+ * Standard site collection type definitions
+ * Types for site.standard.publication and site.standard.document
+ */
+
+import type { ATProtocolBlob, ATProtocolRecord } from './defineBase';
+
+/**
+ * Standard publication record value structure
+ */
+export interface StandardPublicationValue {
+  $type: string;
+  name: string;
+  url: string; // full base URL, e.g. "https://blento.app/did:plc:..."
+  icon?: ATProtocolBlob;
+  description?: string;
+}
+
+/**
+ * A single content block inside a linearDocument page
+ */
+export interface StandardContentBlock {
+  $type: string;
+  block: {
+    $type: string;
+    image?: ATProtocolBlob;
+    plaintext?: string;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * A page inside the document content
+ */
+export interface StandardContentPage {
+  id: string;
+  $type: string;
+  blocks?: StandardContentBlock[];
+}
+
+/**
+ * Nested content object
+ */
+export interface StandardDocumentContent {
+  $type: string;
+  pages?: StandardContentPage[];
+}
+
+/**
+ * Standard document record value structure
+ */
+export interface StandardDocumentValue {
+  $type: string;
+  title: string;
+  path: string;
+  site: string; // AT URI reference to site.standard.publication
+  tags?: string[];
+  description?: string;
+  publishedAt?: string;
+  content?: StandardDocumentContent;
+}
+
+/**
+ * Full Standard publication record
+ */
+export type ATProtocolStandardPublication =
+  ATProtocolRecord<StandardPublicationValue>;
+
+/**
+ * Full Standard document record
+ */
+export type ATProtocolStandardDocument =
+  ATProtocolRecord<StandardDocumentValue>;

--- a/src/types/atproto/index.ts
+++ b/src/types/atproto/index.ts
@@ -8,6 +8,17 @@ export type { ATProtocolBlob, ATProtocolRecord, FetchResult, ListRecordsResponse
 // Leaflet types
 export type { ATProtocolDocument, ATProtocolPublication, DocumentValue, PublicationValue } from './defineLeaflet';
 
+// Standard site types
+export type {
+  ATProtocolStandardDocument,
+  ATProtocolStandardPublication,
+  StandardContentBlock,
+  StandardContentPage,
+  StandardDocumentContent,
+  StandardDocumentValue,
+  StandardPublicationValue,
+} from './defineStandard';
+
 // Protopro types
 export type {
   ATProtocolProfile,


### PR DESCRIPTION
## Summary

- Redesigns `/writing` page to match Figma: `PageHeader` + full-width main + `PageFooter`, no sidebar
- Creates `SectionArticle` component (mirrors `SectionPosition`, wraps `CardArticle`)
- Redesigns `CardArticle` to horizontal layout: cover image left, meta/title/subtitle/Read↗ link right
- Migrates data source from `pub.leaflet.document` → `site.standard.document`
- Adds publication allowlist (`ALLOWED_PUBLICATION_RKEYS`) to control which publications appear

## Changes

### New
- `SectionArticle` component (4-file structure)
- `src/types/atproto/defineStandard.ts` — types for `site.standard.publication` and `site.standard.document`
- `buildCoverUrl()` — CDN path for article cover images (`feed_thumbnail`)

### Updated
- `CardArticle` — horizontal layout matching Figma design
- `useLeaflet` — migrated to `site.standard.*` collections; extracts cover from first image block in content; resolves publication `url` field (not `base_path`); applies allowlist filter
- `WritingPage` — uses `PageHeader`, `PageFooter`, `SectionArticle`; no sidebar

## Test plan

- [x] `/writing` page loads and displays articles
- [x] Publication icons appear next to publication names
- [x] Cover images render where available
- [x] "Read ↗" links resolve to correct article URLs
- [x] Publications not in the allowlist are filtered out
- [x] Loading and error states display correctly
- [x] `npm run lint` passes

Closes #27