### PR TITLE
Experiment #29: Grid layout for /writing page

### DIFF
--- a/src/components/CardArticle/CardArticle.styles.ts
+++ b/src/components/CardArticle/CardArticle.styles.ts
@@ -1,14 +1,14 @@
 export const cardWrapper =
-  'flex gap-32 items-start p-24 w-full';
+  'flex flex-col gap-32 items-start w-full';
 
 export const coverImageContainer =
-  'aspect-[16/9] w-[301px] shrink-0 overflow-hidden bg-black-06';
+  'aspect-[16/9] w-full overflow-hidden bg-black-06 shrink-0';
 
 export const coverImage =
   'object-cover w-full h-full';
 
 export const contentContainer =
-  'flex flex-col gap-16 flex-1 min-w-0 items-start';
+  'flex flex-col gap-16 items-start w-full';
 
 export const metaRow =
   'flex gap-8 items-center';

--- a/src/components/CardArticle/CardArticle.tsx
+++ b/src/components/CardArticle/CardArticle.tsx
@@ -12,7 +12,7 @@ export const CardArticle: React.FC<CardArticleProps> = ({ article }) => {
 
   return (
     <div className={styles.cardWrapper}>
-      {/* Cover image */}
+      {/* Cover image — full width, 16:9 */}
       <div className={styles.coverImageContainer}>
         {article.coverImage && (
           <img src={article.coverImage} alt="" className={styles.coverImage} />
@@ -46,7 +46,7 @@ export const CardArticle: React.FC<CardArticleProps> = ({ article }) => {
         {/* Read link */}
         <Link
           href={article.articleUrl}
-          label="Read"
+          label={`Read on ${article.publication}`}
           hasLeftIcon={false}
           hasRightIcon={true}
           iconRight="↗"

--- a/src/components/CardGridArticle/CardGridArticle.styles.ts
+++ b/src/components/CardGridArticle/CardGridArticle.styles.ts
@@ -1,0 +1,9 @@
+import { mergeClasses } from '@/lib/utils/mergeClasses';
+
+// Single column on mobile, 3-column grid from sm (640px) up.
+// h-full ensures auto-rows-fr has a defined height to distribute into.
+export const gridBase = 'flex flex-col w-full ' + 'sm:grid  md:grid-cols-2 2xl:grid-cols-3 gap-24 sm:auto-rows-fr sm:h-full';
+
+export function getGridStyles(className?: string): string {
+  return mergeClasses(gridBase, className);
+}

--- a/src/components/CardGridArticle/CardGridArticle.tsx
+++ b/src/components/CardGridArticle/CardGridArticle.tsx
@@ -1,0 +1,14 @@
+import { CardArticle } from '@/components/CardArticle/CardArticle';
+import React from 'react';
+import { getGridStyles } from './CardGridArticle.styles';
+import type { CardGridArticleProps } from './CardGridArticle.types';
+
+export const CardGridArticle: React.FC<CardGridArticleProps> = ({ cards, className }) => {
+  return (
+    <div className={getGridStyles(className)}>
+      {cards.map((card, index) => (
+        <CardArticle key={index} {...card} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/CardGridArticle/CardGridArticle.types.ts
+++ b/src/components/CardGridArticle/CardGridArticle.types.ts
@@ -1,0 +1,6 @@
+import type { CardArticleProps } from '@/components/CardArticle/CardArticle.types';
+
+export interface CardGridArticleProps {
+  cards: CardArticleProps[];
+  className?: string;
+}

--- a/src/pages/WritingPage.tsx
+++ b/src/pages/WritingPage.tsx
@@ -1,7 +1,7 @@
+import { CardGridArticle } from '@/components/CardGridArticle/CardGridArticle';
 import { PageFooter } from '@/components/PageFooter/PageFooter';
 import { PageHeader } from '@/components/PageHeader/PageHeader';
 import { Paragraph } from '@/components/Paragraph/Paragraph';
-import { SectionArticle } from '@/components/SectionArticle/SectionArticle';
 import { useLeaflet } from '@/hooks/atproto';
 import type { JSX } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -51,14 +51,10 @@ export default function WritingPage(): JSX.Element {
             <Paragraph size="lg">No posts found.</Paragraph>
           )}
 
-          {!loading &&
-            !error &&
-            documents &&
-            documents.map((doc) => (
-              <SectionArticle
-                key={doc.uri}
-                usecase="2/3"
-                article={{
+          {!loading && !error && documents && (
+            <CardGridArticle
+              cards={documents.map((doc) => ({
+                article: {
                   title: doc.title,
                   subtitle: doc.description || '',
                   coverImage: doc.coverImage || '',
@@ -66,9 +62,10 @@ export default function WritingPage(): JSX.Element {
                   publication: doc.publication.name,
                   publicationIcon: doc.publication.icon,
                   published: doc.publishedAt,
-                }}
-              />
-            ))}
+                },
+              }))}
+            />
+          )}
         </main>
 
         <PageFooter />


### PR DESCRIPTION
## Summary

Experimental grid layout for the `/writing` page. Replaces the single-column `SectionArticle` list with a responsive 3-column card grid.

- Redesigned `CardArticle` to vertical layout: full-width 16:9 cover image on top, meta/title/subtitle/link stacked below
- New `CardGridArticle` component: responsive grid container (1-col mobile → 2-col md → 3-col 2xl)
- `WritingPage` now delegates entirely to `CardGridArticle`
- Read link updated to "Read on {Publication}" for clearer attribution

## Test plan

- [ ] `/writing` renders a responsive grid of article cards
- [ ] Cover images display at 16:9 above the text content
- [ ] Publication avatar, name, separator and date appear in the meta row
- [ ] Read link reads "Read on {publication name}" and opens the article
- [ ] Grid collapses to 2-col on md, 1-col on mobile
- [ ] Loading, error, and empty states still work
- [ ] `npm run lint` passes

Closes #29