### PR TITLE
Feature #34: Contact page at /contact

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import AboutPage from '@/pages/AboutPage';
+import ContactPage from '@/pages/ContactPage';
 import HomePage from '@/pages/HomePage';
 import ProjectsPage from '@/pages/ProjectsPage';
 import WorksPage from '@/pages/PortfolioPage';
@@ -43,6 +44,7 @@ const App: React.FC = () => {
         <Route path="/works" element={<WorksPage />} />
         <Route path="/writing" element={<WritingPage />} />
         <Route path="/projects" element={<ProjectsPage />} />
+        <Route path="/contact" element={<ContactPage />} />
         {/* <Route path="/studies" element={<Studies />} /> */}
       </Routes>
     </div>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,0 +1,73 @@
+import { Link } from '@/components/Link/Link';
+import { PageFooter } from '@/components/PageFooter/PageFooter';
+import { PageHeader } from '@/components/PageHeader/PageHeader';
+import type { JSX } from 'react';
+import { Helmet } from 'react-helmet-async';
+
+const CONTACT_LINKS = [
+  {
+    label: 'Follow me on Bluesky',
+    href: 'https://bsky.app/profile/renderg.host',
+  },
+  {
+    label: 'Connect on LinkedIn',
+    href: 'https://www.linkedin.com/in/barrymprendergast/',
+  },
+  {
+    label: 'Book a Meeting',
+    href: 'https://calendly.com/barry-prendergast',
+  },
+];
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'ContactPage',
+  name: 'Contact Barry Prendergast',
+  url: 'https://renderg.host/contact',
+  mainEntity: {
+    '@type': 'Person',
+    name: 'Barry Prendergast',
+    url: 'https://renderg.host',
+  },
+};
+
+export default function ContactPage(): JSX.Element {
+  return (
+    <>
+      <Helmet>
+        <title>Contact | Barry Prendergast</title>
+        <meta name="description" content="Get in touch with Barry Prendergast via Bluesky, LinkedIn, or Calendly." />
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      </Helmet>
+
+      <div className="min-h-screen flex flex-col bg-whitesmoke">
+        <PageHeader pageTitle="Contact" />
+
+        <main className="flex-1 flex flex-col px-24 pt-32 pb-64">
+          {/* Statement */}
+          <p className="font-sans font-black text-[40px] leading-[48px] sm:text-[56px] sm:leading-[64px] lg:text-[72px] lg:leading-[80px] xl:text-[96px] xl:leading-[104px] text-black max-w-[1400px]">
+            Let&apos;s talk about working together to build the right things, in the right way.
+          </p>
+
+          {/* Contact links */}
+          <div className="flex flex-col sm:flex-row gap-16 sm:gap-32 items-start pt-64">
+            {CONTACT_LINKS.map((link) => (
+              <Link
+                key={link.label}
+                href={link.href}
+                label={link.label}
+                size="medium"
+                usecase="default"
+                hasLeftIcon={false}
+                hasRightIcon={true}
+                iconRight="→"
+              />
+            ))}
+          </div>
+        </main>
+
+        <PageFooter />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- New `ContactPage` at `/contact` — full-viewport layout matching the homepage feel
- Statement text scales responsively from 40px → 96px
- Three contact links (Bluesky, LinkedIn, Calendly) using the existing `Link` component at `size="medium"`
- Route wired in `App.tsx`

## Test plan
- [x] Visit `/contact` and verify the layout fills the screen
- [x] Statement and links render correctly at mobile, tablet, and desktop
- [x] All three links open in a new tab
- [x] No lint errors

Closes #34