### PR TITLE
Feature #41: Impressum page and contact improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import AboutPage from '@/pages/AboutPage';
+import ImpressumPage from '@/pages/ImpressumPage';
 import ContactPage from '@/pages/ContactPage';
 import HomePage from '@/pages/HomePage';
 import ProjectsPage from '@/pages/ProjectsPage';
@@ -53,6 +54,7 @@ const App: React.FC = () => {
         <Route path="/writing" element={<WritingPage />} />
         <Route path="/projects" element={<ProjectsPage />} />
         <Route path="/contact" element={<ContactPage />} />
+        <Route path="/impressum" element={<ImpressumPage />} />
         {/* <Route path="/studies" element={<Studies />} /> */}
       </Routes>
     </div>

--- a/src/components/HomeFooter/HomeFooter.constants.ts
+++ b/src/components/HomeFooter/HomeFooter.constants.ts
@@ -9,6 +9,7 @@ export const SOCIAL_LINKS: NavLink[] = [
   { label: 'Bluesky', href: 'https://bsky.app/profile/renderg.host' },
   { label: 'Calendar', href: 'https://calendly.com/barry-prendergast' },
   { label: 'LinkedIn', href: 'https://linkedin.com/in/barrymprendergast' },
+  { label: 'Mail', href: 'mailto:me@renderg.host' },
 ];
 
 export const DEFAULT_COPYRIGHT = `© ${new Date().getFullYear()} Barry Prendergast`;

--- a/src/components/HomeFooter/HomeFooter.constants.ts
+++ b/src/components/HomeFooter/HomeFooter.constants.ts
@@ -9,7 +9,7 @@ export const SOCIAL_LINKS: NavLink[] = [
   { label: 'Bluesky', href: 'https://bsky.app/profile/renderg.host' },
   { label: 'Calendar', href: 'https://calendly.com/barry-prendergast' },
   { label: 'LinkedIn', href: 'https://linkedin.com/in/barrymprendergast' },
-  { label: 'Mail', href: 'mailto:me@renderg.host' },
+  { label: 'Mail', href: 'mailto:contact@renderg.host' },
 ];
 
 export const DEFAULT_COPYRIGHT = `© ${new Date().getFullYear()} Barry Prendergast`;

--- a/src/components/PageFooter/PageFooter.constants.ts
+++ b/src/components/PageFooter/PageFooter.constants.ts
@@ -9,6 +9,7 @@ export const SOCIAL_LINKS: NavLink[] = [
   { label: 'Bluesky', href: 'https://bsky.app/profile/renderg.host' },
   { label: 'Calendar', href: 'https://calendly.com/barry-prendergast' },
   { label: 'LinkedIn', href: 'https://linkedin.com/in/barrymprendergast' },
+  { label: 'Mail', href: 'mailto:me@renderg.host' },
 ];
 
 export const DEFAULT_COPYRIGHT = `© ${new Date().getFullYear()} Barry Prendergast`;

--- a/src/components/PageFooter/PageFooter.constants.ts
+++ b/src/components/PageFooter/PageFooter.constants.ts
@@ -9,7 +9,7 @@ export const SOCIAL_LINKS: NavLink[] = [
   { label: 'Bluesky', href: 'https://bsky.app/profile/renderg.host' },
   { label: 'Calendar', href: 'https://calendly.com/barry-prendergast' },
   { label: 'LinkedIn', href: 'https://linkedin.com/in/barrymprendergast' },
-  { label: 'Mail', href: 'mailto:me@renderg.host' },
+  { label: 'Mail', href: 'mailto:contact@renderg.host' },
 ];
 
 export const DEFAULT_COPYRIGHT = `© ${new Date().getFullYear()} Barry Prendergast`;

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -17,6 +17,10 @@ const CONTACT_LINKS = [
     label: 'Book a Meeting',
     href: 'https://calendly.com/barry-prendergast',
   },
+  {
+    label: 'Send a Mail',
+    href: 'mailto:contact@renderg.host',
+  },
 ];
 
 const jsonLd = {
@@ -59,8 +63,7 @@ export default function ContactPage(): JSX.Element {
                 size="medium"
                 usecase="default"
                 hasLeftIcon={false}
-                hasRightIcon={true}
-                iconRight="→"
+                hasRightIcon={false}
               />
             ))}
           </div>

--- a/src/pages/ImpressumPage.tsx
+++ b/src/pages/ImpressumPage.tsx
@@ -1,0 +1,71 @@
+import { PageFooter } from '@/components/PageFooter/PageFooter';
+import { PageHeader } from '@/components/PageHeader/PageHeader';
+import type { JSX } from 'react';
+import { Helmet } from 'react-helmet-async';
+
+export default function ImpressumPage(): JSX.Element {
+  return (
+    <>
+      <Helmet>
+        <title>Impressum | Barry Prendergast</title>
+        <meta name="description" content="Legal disclosure for renderg.host pursuant to § 5 DDG." />
+        <meta name="robots" content="noindex" />
+      </Helmet>
+
+      <div className="min-h-screen flex flex-col bg-whitesmoke">
+        <PageHeader pageTitle="Impressum" />
+
+        <main className="flex-1 flex flex-col gap-32 px-24 pt-32 pb-128 max-w-[720px]">
+
+          <section className="flex flex-col gap-8">
+            <p className="font-sans font-black text-base leading-[24px] text-black">
+              Angaben gemäß § 5 DDG
+            </p>
+            <p className="font-sans font-regular text-base leading-[28px] text-black">
+              Barry Prendergast<br />
+              Friedrich-Engels-Straße 11<br />
+              15537 Grünheide (Mark)<br />
+              Deutschland
+            </p>
+          </section>
+
+          <section className="flex flex-col gap-8">
+            <p className="font-sans font-black text-base leading-[24px] text-black">
+              Kontakt
+            </p>
+            <p className="font-sans font-regular text-base leading-[28px] text-black">
+              E-Mail:{' '}
+              <a
+                href="mailto:me@renderg.host"
+                className="underline underline-offset-4"
+              >
+                me@renderg.host
+              </a>
+            </p>
+          </section>
+
+          <section className="flex flex-col gap-8">
+            <p className="font-sans font-black text-base leading-[24px] text-black">
+              Umsatzsteuer-ID
+            </p>
+            <p className="font-sans font-regular text-base leading-[28px] text-black">
+              Umsatzsteuer-Identifikationsnummer gemäß § 27a Umsatzsteuergesetz: DE325048686
+            </p>
+          </section>
+
+          <section className="flex flex-col gap-8">
+            <p className="font-sans font-black text-base leading-[24px] text-black">
+              Berufsbezeichnung
+            </p>
+            <p className="font-sans font-regular text-base leading-[28px] text-black">
+              Freiberuflicher Designer
+            </p>
+          </section>
+
+        </main>
+
+        <PageFooter />
+      </div>
+    </>
+  );
+}

--- a/src/pages/ImpressumPage.tsx
+++ b/src/pages/ImpressumPage.tsx
@@ -16,52 +16,40 @@ export default function ImpressumPage(): JSX.Element {
         <PageHeader pageTitle="Impressum" />
 
         <main className="flex-1 flex flex-col gap-32 px-24 pt-32 pb-128 max-w-[720px]">
-
           <section className="flex flex-col gap-8">
-            <p className="font-sans font-black text-base leading-[24px] text-black">
-              Angaben gemäß § 5 DDG
-            </p>
+            <p className="font-sans font-black text-base leading-[24px] text-black">Angaben gemäß § 5 DDG</p>
             <p className="font-sans font-regular text-base leading-[28px] text-black">
-              Barry Prendergast<br />
-              Friedrich-Engels-Straße 11<br />
-              15537 Grünheide (Mark)<br />
+              Barry Prendergast
+              <br />
+              Friedrich-Engels-Straße 11
+              <br />
+              15537 Grünheide (Mark)
+              <br />
               Deutschland
             </p>
           </section>
 
           <section className="flex flex-col gap-8">
-            <p className="font-sans font-black text-base leading-[24px] text-black">
-              Kontakt
-            </p>
+            <p className="font-sans font-black text-base leading-[24px] text-black">Kontakt</p>
             <p className="font-sans font-regular text-base leading-[28px] text-black">
               E-Mail:{' '}
-              <a
-                href="mailto:me@renderg.host"
-                className="underline underline-offset-4"
-              >
-                me@renderg.host
+              <a href="mailto:contact@renderg.host" className="underline underline-offset-4">
+                contact@renderg.host
               </a>
             </p>
           </section>
 
           <section className="flex flex-col gap-8">
-            <p className="font-sans font-black text-base leading-[24px] text-black">
-              Umsatzsteuer-ID
-            </p>
+            <p className="font-sans font-black text-base leading-[24px] text-black">Umsatzsteuer-ID</p>
             <p className="font-sans font-regular text-base leading-[28px] text-black">
               Umsatzsteuer-Identifikationsnummer gemäß § 27a Umsatzsteuergesetz: DE325048686
             </p>
           </section>
 
           <section className="flex flex-col gap-8">
-            <p className="font-sans font-black text-base leading-[24px] text-black">
-              Berufsbezeichnung
-            </p>
-            <p className="font-sans font-regular text-base leading-[28px] text-black">
-              Freiberuflicher Designer
-            </p>
+            <p className="font-sans font-black text-base leading-[24px] text-black">Berufsbezeichnung</p>
+            <p className="font-sans font-regular text-base leading-[28px] text-black">Freiberuflicher Designer</p>
           </section>
-
         </main>
 
         <PageFooter />


### PR DESCRIPTION
## Summary

- Adds `/impressum` page with all fields required by § 5 DDG: name, address, contact email, VAT ID, and Freiberufler status — `noindex` so it won't appear in search
- Adds 'Send a Mail' as the last link on the Contact page
- Removes arrow icons from Contact page links
- Restores mail link (`contact@renderg.host`) in `PageFooter` and `HomeFooter`

## Test plan

- [x] Visit `/impressum` — all legal fields present and correct
- [x] Visit `/contact` — mail link appears last, no arrows on any link
- [x] Footer mail link works on all pages
- [x] `npm run build` passes

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)