### PR TITLE
feat: SectionReadingList with live bookhive data (#44)

### DIFF
--- a/src/components/CardBook/CardBook.constants.ts
+++ b/src/components/CardBook/CardBook.constants.ts
@@ -1,0 +1,2 @@
+export const TOTAL_STARS = 5;
+export const STAR_CHAR = '★';

--- a/src/components/CardBook/CardBook.styles.ts
+++ b/src/components/CardBook/CardBook.styles.ts
@@ -1,0 +1,22 @@
+export const cardWrapper = 'flex flex-col gap-8 items-start w-full max-w-[400px]';
+
+export const coverWrapper =
+  'aspect-[2/3] w-full bg-black-06 overflow-hidden relative shrink-0';
+
+export const coverImage =
+  'absolute inset-0 w-full h-full object-cover';
+
+export const coverPlaceholder =
+  'absolute inset-0 w-full h-full bg-black-10';
+
+export const titleStyles =
+  'font-sans font-bold text-base leading-[20px] text-black line-clamp-2';
+
+export const authorStyles =
+  'font-sans font-medium text-[12px] leading-[18px] text-dimgray line-clamp-1';
+
+export const starsWrapper = 'flex items-center gap-2';
+
+export const starFilled = 'text-black text-[12px] leading-none';
+
+export const starEmpty = 'text-dimgray text-[12px] leading-none';

--- a/src/components/CardBook/CardBook.tsx
+++ b/src/components/CardBook/CardBook.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { STAR_CHAR, TOTAL_STARS } from './CardBook.constants';
+import {
+  authorStyles,
+  cardWrapper,
+  coverImage,
+  coverPlaceholder,
+  coverWrapper,
+  starEmpty,
+  starFilled,
+  starsWrapper,
+  titleStyles,
+} from './CardBook.styles';
+import type { CardBookProps } from './CardBook.types';
+
+export const CardBook: React.FC<CardBookProps> = ({
+  title,
+  authors,
+  coverUrl,
+  stars,
+}) => {
+  return (
+    <div className={cardWrapper}>
+      <div className={coverWrapper}>
+        {coverUrl ? (
+          <img src={coverUrl} alt={title} className={coverImage} />
+        ) : (
+          <div className={coverPlaceholder} />
+        )}
+      </div>
+
+      <p className={titleStyles}>{title}</p>
+      <p className={authorStyles}>{authors.join(', ')}</p>
+
+      {stars !== undefined && (
+        <div className={starsWrapper}>
+          {Array.from({ length: TOTAL_STARS }, (_, i) => (
+            <span key={i} className={i < stars ? starFilled : starEmpty}>
+              {STAR_CHAR}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/CardBook/CardBook.types.ts
+++ b/src/components/CardBook/CardBook.types.ts
@@ -1,0 +1,6 @@
+export interface CardBookProps {
+  title: string;
+  authors: string[];
+  coverUrl?: string;
+  stars?: number;
+}

--- a/src/components/SectionReadingList/SectionReadingList.constants.ts
+++ b/src/components/SectionReadingList/SectionReadingList.constants.ts
@@ -1,0 +1,19 @@
+import { mergeClasses } from '@/lib/utils/mergeClasses';
+
+export const COL_SPAN: Record<'full' | 'large' | 'default' | 'small', string> = {
+  full: 'col-span-4',
+  large: 'col-span-4 md:col-span-3',
+  default: 'col-span-4 md:col-span-2',
+  small: 'col-span-4 md:col-span-1',
+};
+
+const columnBase =
+  'flex flex-col gap-32 items-start justify-self-stretch self-start';
+
+export function getColStyles(
+  usecase: 'full' | 'large' | 'default' | 'small',
+): string {
+  return mergeClasses(columnBase, COL_SPAN[usecase]);
+}
+
+export const BOOKHIVE_URL = 'https://bookhive.buzz/profile/renderg.host';

--- a/src/components/SectionReadingList/SectionReadingList.styles.ts
+++ b/src/components/SectionReadingList/SectionReadingList.styles.ts
@@ -1,0 +1,15 @@
+export const gridWrapper = 'grid grid-cols-4 gap-x-32 gap-y-32 w-full';
+
+export const rowWrapper = 'flex flex-col gap-16 w-full';
+
+export const h2Styles =
+  'font-sans font-black text-2xl text-black w-full';
+
+export const h3Styles =
+  'font-sans font-black text-base text-black w-full';
+
+export const bookGrid =
+  'grid grid-cols-3 md:grid-cols-4 xl:grid-cols-6 2xl:grid-cols-8 gap-16 w-full';
+
+export const loadingStyles =
+  'font-sans font-medium text-base text-dimgray';

--- a/src/components/SectionReadingList/SectionReadingList.tsx
+++ b/src/components/SectionReadingList/SectionReadingList.tsx
@@ -1,0 +1,74 @@
+import { CardBook } from '@/components/CardBook/CardBook';
+import { Link } from '@/components/Link/Link';
+import { useBookhive } from '@/hooks/atproto';
+import React from 'react';
+import { BOOKHIVE_URL, getColStyles } from './SectionReadingList.constants';
+import {
+  bookGrid,
+  gridWrapper,
+  h2Styles,
+  h3Styles,
+  loadingStyles,
+  rowWrapper,
+} from './SectionReadingList.styles';
+import type { SectionReadingListProps } from './SectionReadingList.types';
+
+export const SectionReadingList: React.FC<SectionReadingListProps> = ({
+  usecase = 'full',
+}) => {
+  const { reading, read, loading, error } = useBookhive();
+
+  if (error) return null;
+
+  return (
+    <div className={gridWrapper}>
+      <div className={getColStyles(usecase)}>
+        <h2 className={h2Styles}>My Reading List</h2>
+
+        {loading && <p className={loadingStyles}>Loading reading list…</p>}
+
+        {!loading && reading.length > 0 && (
+          <div className={rowWrapper}>
+            <h3 className={h3Styles}>Currently Reading</h3>
+            <div className={bookGrid}>
+              {reading.map((book) => (
+                <CardBook
+                  key={book.uri}
+                  title={book.title}
+                  authors={book.authors}
+                  coverUrl={book.coverUrl}
+                  stars={book.stars}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {!loading && read.length > 0 && (
+          <div className={rowWrapper}>
+            <h3 className={h3Styles}>Recently Read</h3>
+            <div className={bookGrid}>
+              {read.map((book) => (
+                <CardBook
+                  key={book.uri}
+                  title={book.title}
+                  authors={book.authors}
+                  coverUrl={book.coverUrl}
+                  stars={book.stars}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {!loading && (
+          <Link
+            href={BOOKHIVE_URL}
+            label='View my full reading list'
+            icon='right'
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/SectionReadingList/SectionReadingList.types.ts
+++ b/src/components/SectionReadingList/SectionReadingList.types.ts
@@ -1,0 +1,3 @@
+export interface SectionReadingListProps {
+  usecase?: 'full' | 'large' | 'default' | 'small';
+}

--- a/src/config/atproto/buildUrls.ts
+++ b/src/config/atproto/buildUrls.ts
@@ -20,3 +20,10 @@ export function buildBlobUrl(blobRef: string, did: string = ATPROTO_CONFIG.DID):
 export function buildCoverUrl(blobRef: string, did: string = ATPROTO_CONFIG.DID): string {
   return `${ATPROTO_CONFIG.CDN_URL}/img/feed_thumbnail/plain/${did}/${blobRef}@jpeg`;
 }
+
+/**
+ * Constructs the PDS blob URL for blobs stored on a non-bsky PDS
+ */
+export function buildPdsBlobUrl(cid: string, did: string = ATPROTO_CONFIG.DID): string {
+  return `${ATPROTO_CONFIG.PDS_URL}/xrpc/com.atproto.sync.getBlob?did=${did}&cid=${cid}`;
+}

--- a/src/config/atproto/getConfig.ts
+++ b/src/config/atproto/getConfig.ts
@@ -32,4 +32,5 @@ export const ATPROTO_COLLECTIONS = {
   POSITION: 'id.sifa.profile.position',
   SKILL: 'id.sifa.profile.skill',
   LANGUAGE: 'id.sifa.profile.language',
+  BOOKHIVE_BOOK: 'buzz.bookhive.book',
 } as const;

--- a/src/config/atproto/index.ts
+++ b/src/config/atproto/index.ts
@@ -3,4 +3,4 @@
  */
 
 export { ALLOWED_PUBLICATION_RKEYS, ATPROTO_COLLECTIONS, ATPROTO_CONFIG } from './getConfig';
-export { buildBlobUrl, buildCoverUrl, buildRecordsUrl } from './buildUrls';
+export { buildBlobUrl, buildCoverUrl, buildPdsBlobUrl, buildRecordsUrl } from './buildUrls';

--- a/src/hooks/atproto/index.ts
+++ b/src/hooks/atproto/index.ts
@@ -2,6 +2,8 @@
  * AT Protocol hooks exports
  */
 
+export { useBookhive } from './useBookhive';
+export type { Book, Bookshelf } from './useBookhive';
 export { useLeaflet } from './useLeaflet';
 export type { Document, Publication } from './useLeaflet';
 export { useProtopro } from './useProtopro';

--- a/src/hooks/atproto/useBookhive.ts
+++ b/src/hooks/atproto/useBookhive.ts
@@ -1,0 +1,57 @@
+import { ATPROTO_COLLECTIONS, buildPdsBlobUrl } from '@/config/atproto';
+import type { BookValue } from '@/types/atproto';
+import { useMemo } from 'react';
+import { useRecords } from './useRecords';
+
+export interface Book {
+  uri: string;
+  title: string;
+  authors: string[];
+  coverUrl?: string;
+  stars?: number;
+  status: string;
+  createdAt: string;
+}
+
+export interface Bookshelf {
+  reading: Book[];
+  read: Book[];
+  loading: boolean;
+  error: string | null;
+}
+
+const STATUS_READING = 'buzz.bookhive.defs#reading';
+const STATUS_FINISHED = 'buzz.bookhive.defs#finished';
+const LIMIT = 6;
+
+export function useBookhive(): Bookshelf {
+  const { data, loading, error } = useRecords<BookValue>(
+    ATPROTO_COLLECTIONS.BOOKHIVE_BOOK,
+  );
+
+  const { reading, read } = useMemo(() => {
+    if (!data) return { reading: [], read: [] };
+
+    const books: Book[] = data
+      .filter((r) => r.value.status === STATUS_READING || r.value.status === STATUS_FINISHED)
+      .map((r) => ({
+        uri: r.uri,
+        title: r.value.title,
+        authors: r.value.authors.split('\t').filter(Boolean),
+        coverUrl: r.value.cover ? buildPdsBlobUrl(r.value.cover.ref.$link) : undefined,
+        stars: r.value.stars !== undefined ? Math.round(r.value.stars / 2) : undefined,
+        status: r.value.status ?? '',
+        createdAt: r.value.createdAt,
+      }));
+
+    const byDate = (a: Book, b: Book) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+
+    return {
+      reading: books.filter((b) => b.status === STATUS_READING).sort(byDate).slice(0, LIMIT),
+      read: books.filter((b) => b.status === STATUS_FINISHED).sort(byDate).slice(0, LIMIT),
+    };
+  }, [data]);
+
+  return { reading, read, loading, error };
+}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -3,6 +3,7 @@ import { PageHeader } from '@/components/PageHeader/PageHeader';
 import { SectionHeader } from '@/components/SectionHeader/SectionHeader';
 import { SectionImage } from '@/components/SectionImage/SectionImage';
 import { SectionQuote } from '@/components/SectionQuote/SectionQuote';
+import { SectionReadingList } from '@/components/SectionReadingList/SectionReadingList';
 import { SectionText } from '@/components/SectionText/SectionText';
 import type { JSX } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -81,6 +82,7 @@ export default function AboutPage(): JSX.Element {
           <SectionText body="I've spent almost 20 years helping organisations close the gap between what users need, what technology can (and can't) do, and what a business aspires to achieve, then building products and services that satisfy all three. I believe nothing useful or long-lasting gets made any other way." />
           <SectionText body="I believe that my role as a designer is to help people understand the status quo, and provide them with the tools, processes and knowledge to make postive and meaningful change. For me, that means having timely conversations, exposing complexity, testing risky assumptions, understanding constraints, and making good decisions collaboratively. I aim to leave every team more connected, informed and capable than when I joined them." />
           <SectionText body="In my spare time I enjoy making art and experimental music, writing articles, and some creative coding. I spend as much time outside with my kids as I can, and I read as widely as I can: design theory, systems thinking, information architecture, history, psychology, science fiction, and the occasional manual for fun." />
+          <SectionReadingList />
         </div>
 
         <PageFooter />

--- a/src/types/atproto/defineBookhive.ts
+++ b/src/types/atproto/defineBookhive.ts
@@ -1,0 +1,16 @@
+import type { ATProtocolBlob } from './defineBase';
+
+export interface BookValue {
+  title: string;
+  authors: string;
+  hiveId: string;
+  createdAt: string;
+  cover?: ATProtocolBlob;
+  stars?: number;
+  status?: string;
+  review?: string;
+  owned?: boolean;
+  startedAt?: string;
+  finishedAt?: string;
+  hiveBookUri?: string;
+}

--- a/src/types/atproto/index.ts
+++ b/src/types/atproto/index.ts
@@ -27,6 +27,9 @@ export type {
   ProfileValue,
 } from './defineProtopro';
 
+// Bookhive types
+export type { BookValue } from './defineBookhive';
+
 // Sifa types
 export type {
   SifaLanguageValue,


### PR DESCRIPTION
## Summary

- **SectionReadingList** — new section component on the About page that fetches and displays live book data from the user's AT Protocol PDS (buzz.bookhive.book collection)
- **useBookhive hook** — fetches `buzz.bookhive.book` records, filters by `#reading` and `#finished` status, maps tab-separated authors, converts 1-10 stars to 1-5, builds PDS blob URLs for cover images
- **CardBook component** — displays book cover (2:3 aspect ratio), title, author, and star rating; capped at `max-w-[400px]` to prevent upscaling pixelation
- **Responsive grid** — `grid-cols-3 md:grid-cols-4 xl:grid-cols-6 2xl:grid-cols-8`, shows up to 6 books per shelf
- **Semantic headings** — `<h2>` for "My Reading List", `<h3>` for "Currently Reading" and "Recently Read"
- **ATPROTO_COLLECTIONS** — added `BOOKHIVE_BOOK: 'buzz.bookhive.book'`; `buildPdsBlobUrl` uses direct PDS `com.atproto.sync.getBlob` endpoint (not bsky CDN)

## Test plan

- [x] Visit `/about` — "My Reading List" section appears below biography text
- [x] "Currently Reading" shelf shows books being actively read
- [x] "Recently Read" shelf shows up to 6 most recently finished books
- [x] Book covers load (not placeholder) — PDS blob URL resolves correctly
- [x] Star ratings render correctly (1-5 filled/empty stars)
- [x] "View my full reading list" link appears below both shelves
- [x] Loading state shows while data fetches
- [x] No section renders if there's an error (graceful fallback)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)