### PR TITLE
fix: CardBook links, URL construction, and text wrapping (#47)

### DIFF
--- a/src/components/CardBook/CardBook.styles.ts
+++ b/src/components/CardBook/CardBook.styles.ts
@@ -13,10 +13,10 @@ export const titleStyles =
   'font-sans font-bold text-base leading-[20px] text-black line-clamp-2';
 
 export const authorStyles =
-  'font-sans font-medium text-[12px] leading-[18px] text-dimgray line-clamp-1';
+  'font-sans font-medium text-sm leading-[18px] text-dimgray line-clamp-1';
 
-export const starsWrapper = 'flex items-center gap-2';
+export const starsWrapper = 'flex items-center gap-4';
 
-export const starFilled = 'text-black text-[12px] leading-none';
+export const starFilled = 'text-black text-sm';
 
-export const starEmpty = 'text-dimgray text-[12px] leading-none';
+export const starEmpty = 'text-black-24 text-sm';

--- a/src/components/CardBook/CardBook.tsx
+++ b/src/components/CardBook/CardBook.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@/components/Link/Link';
 import React from 'react';
 import { STAR_CHAR, TOTAL_STARS } from './CardBook.constants';
 import {
@@ -9,7 +10,6 @@ import {
   starEmpty,
   starFilled,
   starsWrapper,
-  titleStyles,
 } from './CardBook.styles';
 import type { CardBookProps } from './CardBook.types';
 
@@ -18,6 +18,7 @@ export const CardBook: React.FC<CardBookProps> = ({
   authors,
   coverUrl,
   stars,
+  href,
 }) => {
   return (
     <div className={cardWrapper}>
@@ -29,7 +30,12 @@ export const CardBook: React.FC<CardBookProps> = ({
         )}
       </div>
 
-      <p className={titleStyles}>{title}</p>
+      {href ? (
+        <Link href={href} label={title} color='black' icon='none' wrap />
+      ) : (
+        <p className='font-sans font-bold text-base leading-[20px] text-black line-clamp-2'>{title}</p>
+      )}
+
       <p className={authorStyles}>{authors.join(', ')}</p>
 
       {stars !== undefined && (

--- a/src/components/CardBook/CardBook.types.ts
+++ b/src/components/CardBook/CardBook.types.ts
@@ -3,4 +3,5 @@ export interface CardBookProps {
   authors: string[];
   coverUrl?: string;
   stars?: number;
+  href?: string;
 }

--- a/src/components/Link/Link.styles.ts
+++ b/src/components/Link/Link.styles.ts
@@ -30,4 +30,9 @@ export const labelStyles =
   'group-focus-visible:decoration-solid ' +
   'shrink-0 overflow-hidden text-ellipsis whitespace-nowrap';
 
+export const labelWrapStyles =
+  'underline decoration-dotted underline-offset-4 ' +
+  'group-hover:decoration-solid ' +
+  'group-focus-visible:decoration-solid';
+
 export const iconStyles = 'shrink-0';

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import { DEFAULT_ICON } from './Link.constants';
-import { getLinkStyles, iconStyles, labelStyles } from './Link.styles';
+import { getLinkStyles, iconStyles, labelStyles, labelWrapStyles } from './Link.styles';
 import type { LinkProps } from './Link.types';
 
 export const Link: React.FC<LinkProps> = ({
@@ -12,6 +12,7 @@ export const Link: React.FC<LinkProps> = ({
   icon = 'none',
   iconChar = DEFAULT_ICON,
   className,
+  wrap = false,
 }) => {
   const isInternal = href.startsWith('/') && !href.startsWith('//');
   const isExternal = href.startsWith('http://') || href.startsWith('https://');
@@ -22,7 +23,7 @@ export const Link: React.FC<LinkProps> = ({
   const content = (
     <>
       {icon === 'left' && iconEl}
-      <span className={labelStyles}>{label}</span>
+      <span className={wrap ? labelWrapStyles : labelStyles}>{label}</span>
       {icon === 'right' && iconEl}
     </>
   );

--- a/src/components/Link/Link.types.ts
+++ b/src/components/Link/Link.types.ts
@@ -10,4 +10,5 @@ export interface LinkProps {
   icon?: LinkIcon;
   iconChar?: string;
   className?: string;
+  wrap?: boolean;
 }

--- a/src/components/SectionReadingList/SectionReadingList.constants.ts
+++ b/src/components/SectionReadingList/SectionReadingList.constants.ts
@@ -17,3 +17,8 @@ export function getColStyles(
 }
 
 export const BOOKHIVE_URL = 'https://bookhive.buzz/profile/renderg.host';
+
+export function buildBookhiveBookUrl(hiveBookUri: string): string {
+  const rkey = hiveBookUri.split('/').at(-1);
+  return `https://bookhive.buzz/books/${rkey}`;
+}

--- a/src/components/SectionReadingList/SectionReadingList.tsx
+++ b/src/components/SectionReadingList/SectionReadingList.tsx
@@ -66,7 +66,7 @@ export const SectionReadingList: React.FC<SectionReadingListProps> = ({
         {!loading && (
           <Link
             href={BOOKHIVE_URL}
-            label='View my full reading list'
+            label='View my reading list on BookHive'
             icon='right'
           />
         )}

--- a/src/components/SectionReadingList/SectionReadingList.tsx
+++ b/src/components/SectionReadingList/SectionReadingList.tsx
@@ -2,7 +2,7 @@ import { CardBook } from '@/components/CardBook/CardBook';
 import { Link } from '@/components/Link/Link';
 import { useBookhive } from '@/hooks/atproto';
 import React from 'react';
-import { BOOKHIVE_URL, getColStyles } from './SectionReadingList.constants';
+import { BOOKHIVE_URL, buildBookhiveBookUrl, getColStyles } from './SectionReadingList.constants';
 import {
   bookGrid,
   gridWrapper,
@@ -38,6 +38,7 @@ export const SectionReadingList: React.FC<SectionReadingListProps> = ({
                   authors={book.authors}
                   coverUrl={book.coverUrl}
                   stars={book.stars}
+                  href={book.hiveBookUri ? buildBookhiveBookUrl(book.hiveBookUri) : undefined}
                 />
               ))}
             </div>
@@ -55,6 +56,7 @@ export const SectionReadingList: React.FC<SectionReadingListProps> = ({
                   authors={book.authors}
                   coverUrl={book.coverUrl}
                   stars={book.stars}
+                  href={book.hiveBookUri ? buildBookhiveBookUrl(book.hiveBookUri) : undefined}
                 />
               ))}
             </div>

--- a/src/hooks/atproto/useBookhive.ts
+++ b/src/hooks/atproto/useBookhive.ts
@@ -11,6 +11,7 @@ export interface Book {
   stars?: number;
   status: string;
   createdAt: string;
+  hiveBookUri?: string;
 }
 
 export interface Bookshelf {
@@ -42,6 +43,7 @@ export function useBookhive(): Bookshelf {
         stars: r.value.stars !== undefined ? Math.round(r.value.stars / 2) : undefined,
         status: r.value.status ?? '',
         createdAt: r.value.createdAt,
+        hiveBookUri: r.value.hiveBookUri ?? `at://did:plc:enu2j5xjlqsjaylv3du4myh4/buzz.bookhive.catalogBook/${r.value.hiveId}`,
       }));
 
     const byDate = (a: Book, b: Book) =>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,7 @@ export default {
 
       // Mono
       black: '#000000',
-      dimgray: '#696969',
+      dimgray: '#3e3e3e',
       white: '#ffffff',
       whitesmoke: '#f2f0f0',
 


### PR DESCRIPTION
## Summary

- Book titles now all link to their bookhive page — URL built from `hiveId` (always present), with a fallback that constructs `hiveBookUri` for older records that predate the field
- Replaced raw `<a>` tag with `Link` component (black variant)
- Added `wrap` prop to `Link` to allow label text to reflow in constrained layouts (previously `whitespace-nowrap` caused titles to overflow card columns)
- Cover and title are now separate sibling elements so `gap` spacing applies naturally between them
- Updated reading list link label copy

## Test plan

- [ ] Visit `/about` — every book title is linked
- [ ] Click a book title — opens `https://bookhive.buzz/books/bk_*` in a new tab
- [ ] Long titles wrap within their card column, no overflow
- [ ] "View my reading list on BookHive →" link visible below the shelves

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)