### PR TITLE
feat: Career page limit, Markdown component, card layout updates (#50)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "latest",
         "react-dom": "latest",
         "react-helmet-async": "latest",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "latest",
         "tailwind-merge": "latest",
         "tailwindcss": "latest"
@@ -1881,7 +1882,6 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -1891,8 +1891,25 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/history": {
       "version": "4.7.11",
@@ -1919,7 +1936,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -1929,7 +1945,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2014,7 +2029,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2330,6 +2344,12 @@
       "peerDependencies": {
         "prettier": ">=3.0.0"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",
@@ -2686,6 +2706,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2923,6 +2953,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2944,7 +2984,36 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3101,6 +3170,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "10.0.1",
@@ -3292,7 +3371,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3310,7 +3388,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
       "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -3387,7 +3464,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3420,7 +3496,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -4114,6 +4189,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4133,6 +4218,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4673,6 +4764,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-attribute-sorter": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/html-attribute-sorter/-/html-attribute-sorter-0.4.3.tgz",
@@ -4681,6 +4812,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -4734,6 +4875,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4756,6 +4903,30 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4904,6 +5075,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4969,6 +5150,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5012,7 +5203,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5455,6 +5645,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5510,7 +5710,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
       "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5531,11 +5730,126 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -5558,7 +5872,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5594,7 +5907,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5629,7 +5941,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5651,7 +5962,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5674,7 +5984,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5695,7 +6004,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5718,7 +6026,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5741,7 +6048,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5762,7 +6068,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5782,7 +6087,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5804,7 +6108,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5825,7 +6128,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5845,7 +6147,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5868,7 +6169,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5885,7 +6185,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5902,7 +6201,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5922,7 +6220,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5942,7 +6239,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5964,7 +6260,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5987,7 +6282,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6004,7 +6298,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -6078,7 +6371,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mvdan-sh": {
@@ -6419,6 +6711,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7059,6 +7376,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -7182,6 +7509,33 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -7323,6 +7677,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remeda": {
@@ -7828,6 +8215,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/sql-formatter": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.5.2.tgz",
@@ -8019,6 +8416,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -8067,6 +8478,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -8300,6 +8729,26 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -8519,14 +8968,87 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8591,6 +9113,34 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.1",
@@ -9041,6 +9591,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "latest",
     "react-dom": "latest",
     "react-helmet-async": "latest",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "latest",
     "tailwind-merge": "latest",
     "tailwindcss": "latest"

--- a/src/components/CardArticle/CardArticle.styles.ts
+++ b/src/components/CardArticle/CardArticle.styles.ts
@@ -1,17 +1,14 @@
 export const cardWrapper =
-  'flex flex-col gap-32 items-start w-full';
+  'flex flex-col items-start w-full bg-white';
 
 export const coverImageContainer =
-  'relative aspect-[16/9] w-full overflow-hidden bg-black-06 shrink-0';
+  'relative aspect-[7/4] w-full overflow-hidden bg-black-06 shrink-0';
 
 export const coverImage =
   'object-cover w-full h-full';
 
-export const coverImageBorder =
-  'absolute inset-0 ring-1 ring-inset ring-black-24 pointer-events-none z-10';
-
 export const contentContainer =
-  'flex flex-col gap-16 items-start w-full';
+  'flex flex-col gap-16 items-start w-full p-32';
 
 export const metaRow =
   'flex gap-8 items-center';
@@ -20,10 +17,10 @@ export const publicationAvatar =
   'size-[28px] object-contain shrink-0';
 
 export const metaText =
-  'text-base font-medium leading-[28px] whitespace-nowrap text-black';
+  'font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
 
 export const title =
-  'text-[24px] font-black leading-[32px] text-black w-full';
+  'font-sans font-black text-[32px] leading-[40px] text-black w-full';
 
 export const subtitle =
-  'text-base font-medium leading-[28px] text-black overflow-hidden text-ellipsis w-full';
+  'font-sans font-medium text-base leading-[28px] text-black w-full';

--- a/src/components/CardArticle/CardArticle.tsx
+++ b/src/components/CardArticle/CardArticle.tsx
@@ -12,12 +12,11 @@ export const CardArticle: React.FC<CardArticleProps> = ({ article }) => {
 
   return (
     <div className={styles.cardWrapper}>
-      {/* Cover image — full width, 16:9 */}
+      {/* Cover image */}
       <div className={styles.coverImageContainer}>
         {article.coverImage && (
           <img src={article.coverImage} alt="" className={styles.coverImage} />
         )}
-        <div className={styles.coverImageBorder} />
       </div>
 
       {/* Content */}
@@ -47,8 +46,9 @@ export const CardArticle: React.FC<CardArticleProps> = ({ article }) => {
         {/* Read link */}
         <Link
           href={article.articleUrl}
-          label={`Read on '${article.publication}'`}
+          label='Read'
           icon='right'
+          iconChar='↗'
         />
       </div>
     </div>

--- a/src/components/CardCaseStudy/CardCaseStudy.styles.ts
+++ b/src/components/CardCaseStudy/CardCaseStudy.styles.ts
@@ -1,23 +1,23 @@
 export const cardWrapper =
-  'flex flex-col gap-32 items-start w-full';
+  'flex flex-col items-start w-full bg-white';
 
 export const coverImageContainer =
-  'aspect-[16/9] w-full overflow-hidden bg-black-06 shrink-0';
+  'relative aspect-[7/4] w-full overflow-hidden bg-black-06 shrink-0';
 
 export const coverImage =
   'object-cover w-full h-full';
 
 export const contentContainer =
-  'flex flex-col gap-16 items-start w-full';
+  'flex flex-col gap-16 items-start w-full p-32';
 
 export const metaRow =
   'flex gap-8 items-center';
 
 export const metaText =
-  'text-base font-medium leading-[28px] whitespace-nowrap text-black';
+  'font-sans font-medium text-base leading-[28px] whitespace-nowrap text-black';
 
 export const title =
-  'text-[24px] font-black leading-[32px] text-black w-full';
+  'font-sans font-black text-[32px] leading-[40px] text-black w-full';
 
 export const summary =
-  'text-base font-medium leading-[28px] text-black overflow-hidden text-ellipsis w-full';
+  'font-sans font-medium text-base leading-[28px] text-black w-full';

--- a/src/components/CardCaseStudy/CardCaseStudy.tsx
+++ b/src/components/CardCaseStudy/CardCaseStudy.tsx
@@ -6,7 +6,7 @@ import type { CardCaseStudyProps } from './CardCaseStudy.types';
 export const CardCaseStudy: React.FC<CardCaseStudyProps> = ({ caseStudy }) => {
   return (
     <div className={styles.cardWrapper}>
-      {/* Cover image — full width, 16:9 */}
+      {/* Cover image */}
       <div className={styles.coverImageContainer}>
         {caseStudy.coverImage && (
           <img
@@ -19,11 +19,17 @@ export const CardCaseStudy: React.FC<CardCaseStudyProps> = ({ caseStudy }) => {
 
       {/* Content */}
       <div className={styles.contentContainer}>
-        {/* Meta row: affiliation · type */}
+        {/* Meta row: affiliation · type · year */}
         <div className={styles.metaRow}>
           <span className={styles.metaText}>{caseStudy.affiliation}</span>
           <span className={styles.metaText}>·</span>
           <span className={styles.metaText}>{caseStudy.type}</span>
+          {caseStudy.yearEnded && (
+            <>
+              <span className={styles.metaText}>·</span>
+              <span className={styles.metaText}>{caseStudy.yearEnded}</span>
+            </>
+          )}
         </div>
 
         {/* Title */}
@@ -37,8 +43,9 @@ export const CardCaseStudy: React.FC<CardCaseStudyProps> = ({ caseStudy }) => {
         {/* Link */}
         <Link
           href={`/portfolio/${caseStudy.slug}`}
-          label='View case study'
+          label='Read'
           icon='right'
+          iconChar='↗'
         />
       </div>
     </div>

--- a/src/components/CardCaseStudy/CardCaseStudy.types.ts
+++ b/src/components/CardCaseStudy/CardCaseStudy.types.ts
@@ -6,5 +6,6 @@ export interface CardCaseStudyProps {
     coverImage: string;
     affiliation: string;
     type: string;
+    yearEnded?: string;
   };
 }

--- a/src/components/CardGridArticle/CardGridArticle.styles.ts
+++ b/src/components/CardGridArticle/CardGridArticle.styles.ts
@@ -2,7 +2,7 @@ import { mergeClasses } from '@/lib/utils/mergeClasses';
 
 // Single column on mobile, 3-column grid from sm (640px) up.
 // h-full ensures auto-rows-fr has a defined height to distribute into.
-export const gridBase = 'flex flex-col w-full ' + 'sm:grid  md:grid-cols-2 2xl:grid-cols-3 gap-24 sm:auto-rows-fr sm:h-full';
+export const gridBase = 'flex flex-col w-full sm:grid md:grid-cols-2 2xl:grid-cols-3 gap-24';
 
 export function getGridStyles(className?: string): string {
   return mergeClasses(gridBase, className);

--- a/src/components/CardGridCaseStudy/CardGridCaseStudy.styles.ts
+++ b/src/components/CardGridCaseStudy/CardGridCaseStudy.styles.ts
@@ -1,8 +1,7 @@
 import { mergeClasses } from '@/lib/utils/mergeClasses';
 
 export const gridBase =
-  'flex flex-col w-full ' +
-  'sm:grid md:grid-cols-2 2xl:grid-cols-3 gap-24 sm:auto-rows-fr sm:h-full';
+  'flex flex-col w-full sm:grid md:grid-cols-2 2xl:grid-cols-3 gap-24';
 
 export function getGridStyles(className?: string): string {
   return mergeClasses(gridBase, className);

--- a/src/components/CardGridProject/CardGridProject.styles.ts
+++ b/src/components/CardGridProject/CardGridProject.styles.ts
@@ -1,8 +1,7 @@
 import { mergeClasses } from '@/lib/utils/mergeClasses';
 
 export const gridBase =
-  'flex flex-col w-full ' +
-  'sm:grid md:grid-cols-2 2xl:grid-cols-3 gap-24 sm:auto-rows-fr sm:h-full';
+  'flex flex-col w-full sm:grid md:grid-cols-2 2xl:grid-cols-3 gap-24';
 
 export function getGridStyles(className?: string): string {
   return mergeClasses(gridBase, className);

--- a/src/components/CardPosition/CardPosition.styles.ts
+++ b/src/components/CardPosition/CardPosition.styles.ts
@@ -1,32 +1,25 @@
-export const cardWrapper =
-  'flex flex-col gap-16 items-start w-full';
+import { mergeClasses } from '@/lib/utils/mergeClasses';
 
-export const metaRow =
-  'flex items-start justify-between w-full';
+const cardBase = 'flex flex-col gap-16 items-start p-32 w-full';
 
-export const metaLeft =
-  'flex gap-4 items-start font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
+export function getCardWrapper(isCurrent: boolean): string {
+  return mergeClasses(cardBase, isCurrent ? 'bg-white' : 'bg-black-06');
+}
 
-export const metaRight =
-  'flex gap-16 items-center';
-
-export const dateRow =
-  'flex gap-1 items-center font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
-
-export const currentBadge =
-  'bg-yellow px-8 font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
+export const titleRow =
+  'flex items-start justify-between w-full gap-16';
 
 export const titleStyles =
-  'font-sans font-black text-[24px] leading-[32px] text-black w-full overflow-hidden text-ellipsis';
+  'font-sans font-black text-[24px] leading-[32px] text-black';
 
-export const descriptionStyles =
-  'font-sans font-medium text-base leading-[28px] text-black w-full overflow-hidden text-ellipsis';
+export const currentBadge =
+  'bg-yellow px-8 font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap shrink-0';
 
-export const locationRow =
-  'flex gap-16 items-start';
+export const metaRow =
+  'flex items-center justify-between w-full';
 
-export const locationText =
-  'flex gap-1 items-start font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
+export const metaLeft =
+  'flex gap-8 items-center font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
 
-export const remoteBadge =
-  'bg-black-10 px-8 font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';
+export const metaRight =
+  'flex gap-1 items-center font-sans font-medium text-base leading-[28px] text-black whitespace-nowrap';

--- a/src/components/CardPosition/CardPosition.tsx
+++ b/src/components/CardPosition/CardPosition.tsx
@@ -1,3 +1,4 @@
+import { Markdown } from '@/components/Markdown/Markdown';
 import React from 'react';
 import * as styles from './CardPosition.styles';
 import type { CardPositionProps } from './CardPosition.types';
@@ -12,67 +13,53 @@ export const CardPosition: React.FC<CardPositionProps> = ({
   company,
   title,
   description,
-  employmentType,
   startedAt,
   endedAt,
   location,
-  remote,
 }) => {
   const isCurrent = !endedAt;
   const formattedStart = startedAt ? formatDate(startedAt) : null;
-  const formattedEnd = endedAt ? formatDate(endedAt) : null;
+  const formattedEnd = endedAt ? formatDate(endedAt) : 'Date';
+
+  const hasLocation = location && (location.city || location.country);
 
   return (
-    <div className={styles.cardWrapper}>
+    <div className={styles.getCardWrapper(isCurrent)}>
 
+      {/* Title row */}
+      <div className={styles.titleRow}>
+        <p className={styles.titleStyles}>{title}</p>
+        {isCurrent && (
+          <span className={styles.currentBadge}>Current</span>
+        )}
+      </div>
 
-      {/* Title */}
-      <p className={styles.titleStyles}>{title}</p>
-
-      {/* Meta row: company · type on left, badge + dates on right */}
+      {/* Meta row */}
       <div className={styles.metaRow}>
         <div className={styles.metaLeft}>
           <span>{company}</span>
-          {employmentType && (
+          {hasLocation && (
             <>
               <span>·</span>
-              <span>{employmentType}</span>
+              <span>
+                {location.city}
+                {location.city && location.country && ', '}
+                {location.country}
+              </span>
             </>
           )}
         </div>
-        <div className={styles.metaRight}>
-          {isCurrent && (
-            <span className={styles.currentBadge}>Current</span>
-          )}
-          {formattedStart && (
-            <div className={styles.dateRow}>
-              <span>{formattedStart}</span>
-              <span>–</span>
-              <span>{formattedEnd ?? 'Date'}</span>
-            </div>
-          )}
-        </div>
+        {formattedStart && (
+          <div className={styles.metaRight}>
+            <span>{formattedStart}</span>
+            <span>–</span>
+            <span>{formattedEnd}</span>
+          </div>
+        )}
       </div>
-      {/* Description */}
-      {description && (
-        <p className={styles.descriptionStyles}>{description}</p>
-      )}
 
-      {/* Location row */}
-      {(location || remote) && (
-        <div className={styles.locationRow}>
-          {location && (location.city || location.country) && (
-            <div className={styles.locationText}>
-              {location.city && <span>{location.city}</span>}
-              {location.city && location.country && <span>,</span>}
-              {location.country && <span>{location.country}</span>}
-            </div>
-          )}
-          {remote && (
-            <span className={styles.remoteBadge}>Remote</span>
-          )}
-        </div>
-      )}
+      {/* Description */}
+      {description && <Markdown>{description}</Markdown>}
     </div>
   );
 };

--- a/src/components/CardProject/CardProject.styles.ts
+++ b/src/components/CardProject/CardProject.styles.ts
@@ -1,26 +1,23 @@
 export const cardWrapper =
-  'flex flex-col gap-32 items-start w-full';
+  'flex flex-col items-start w-full bg-white';
 
 export const thumbnailContainer =
-  'relative aspect-[16/9] w-full overflow-hidden bg-black-06 shrink-0';
+  'relative aspect-[7/4] w-full overflow-hidden bg-black-06 shrink-0';
 
 export const thumbnail =
   'object-cover w-full h-full';
 
-export const thumbnailBorder =
-  'absolute inset-0 ring-1 ring-inset ring-black-24 pointer-events-none z-10';
-
 export const contentContainer =
-  'flex flex-col gap-16 items-start w-full';
+  'flex flex-col gap-16 items-start w-full p-32';
 
 export const badgeRow =
   'flex gap-8 items-center flex-wrap';
 
 export const title =
-  'text-[24px] font-black leading-[32px] text-black w-full';
+  'font-sans font-black text-[32px] leading-[40px] text-black w-full';
 
 export const description =
-  'text-base font-medium leading-[28px] text-black overflow-hidden text-ellipsis w-full';
+  'font-sans font-medium text-base leading-[28px] text-black w-full';
 
 export const linksRow =
   'flex flex-row gap-8 items-center flex-wrap';

--- a/src/components/CardProject/CardProject.tsx
+++ b/src/components/CardProject/CardProject.tsx
@@ -7,7 +7,7 @@ import type { CardProjectProps } from './CardProject.types';
 export const CardProject: React.FC<CardProjectProps> = ({ project }) => {
   return (
     <div className={styles.cardWrapper}>
-      {/* Thumbnail — full width, 16:9 */}
+      {/* Thumbnail */}
       <div className={styles.thumbnailContainer}>
         {project.thumbnail && (
           <img
@@ -16,7 +16,6 @@ export const CardProject: React.FC<CardProjectProps> = ({ project }) => {
             className={styles.thumbnail}
           />
         )}
-        <div className={styles.thumbnailBorder} />
       </div>
 
       {/* Content */}
@@ -52,6 +51,7 @@ export const CardProject: React.FC<CardProjectProps> = ({ project }) => {
                 href={project.projectUrl}
                 label="View the Project"
                 icon='right'
+                iconChar='↗'
               />
             )}
             {project.sourceUrl && (
@@ -59,6 +59,7 @@ export const CardProject: React.FC<CardProjectProps> = ({ project }) => {
                 href={project.sourceUrl}
                 label="View the Source"
                 icon='right'
+                iconChar='↗'
               />
             )}
           </div>

--- a/src/components/Markdown/Markdown.styles.ts
+++ b/src/components/Markdown/Markdown.styles.ts
@@ -1,0 +1,16 @@
+export const wrapper = 'flex flex-col gap-8 w-full';
+
+export const paragraph = 'font-sans font-medium text-base leading-[28px] text-black';
+
+export const strong = 'font-bold';
+
+export const em = 'italic';
+
+export const link =
+  'font-semibold text-blue underline underline-offset-2 hover:text-mediumblue transition-colors';
+
+export const ul = 'flex flex-col gap-4 pl-16 list-disc';
+
+export const ol = 'flex flex-col gap-4 pl-16 list-decimal';
+
+export const li = 'font-sans font-medium text-base leading-[28px] text-black';

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { mergeClasses } from '@/lib/utils/mergeClasses';
+import * as styles from './Markdown.styles';
+import type { MarkdownProps } from './Markdown.types';
+
+export const Markdown: React.FC<MarkdownProps> = ({ children, className }) => {
+  return (
+    <div className={mergeClasses(styles.wrapper, className)}>
+      <ReactMarkdown
+        components={{
+          p: ({ children: c }) => <p className={styles.paragraph}>{c}</p>,
+          strong: ({ children: c }) => <strong className={styles.strong}>{c}</strong>,
+          em: ({ children: c }) => <em className={styles.em}>{c}</em>,
+          a: ({ href, children: c }) => (
+            <a href={href} className={styles.link} target="_blank" rel="noopener noreferrer">
+              {c}
+            </a>
+          ),
+          ul: ({ children: c }) => <ul className={styles.ul}>{c}</ul>,
+          ol: ({ children: c }) => <ol className={styles.ol}>{c}</ol>,
+          li: ({ children: c }) => <li className={styles.li}>{c}</li>,
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+};

--- a/src/components/Markdown/Markdown.types.ts
+++ b/src/components/Markdown/Markdown.types.ts
@@ -1,0 +1,4 @@
+export interface MarkdownProps {
+  children: string;
+  className?: string;
+}

--- a/src/components/PageHeader/PageHeader.styles.ts
+++ b/src/components/PageHeader/PageHeader.styles.ts
@@ -13,7 +13,7 @@ export const navGroup =
 export const breadcrumbGroup = 'flex items-center gap-8 md:order-1';
 
 export const breadcrumbSeparator =
-  'font-sans font-medium text-base leading-[28px] text-dimgray select-none';
+  'font-sans font-medium text-base text-dimgray select-none';
 
 
 export function getWrapperStyles(className?: string): string {

--- a/src/components/SectionHeader/SectionHeader.styles.ts
+++ b/src/components/SectionHeader/SectionHeader.styles.ts
@@ -1,4 +1,4 @@
-export const gridWrapper = 'grid grid-cols-4 gap-x-32 gap-y-32 w-full';
+export const gridWrapper = 'grid grid-cols-4 gap-x-32 gap-y-32 pb-24 w-full';
 
 export const titleStyles =
   'font-sans font-black text-4xl text-black';

--- a/src/data/json/casestudies.json
+++ b/src/data/json/casestudies.json
@@ -1,7 +1,7 @@
 [
   {
     "affiliation": "Brandwatch",
-    "affiliationURL": "https://medium.com/@render_ghost/",
+    "affiliationURL": "https://www.brandwatch.com/",
     "body": "<p id=\"\">Maecenas faucibus mollis interdum. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed posuere consectetur est at lobortis. Etiam porta sem malesuada magna mollis euismod.</p><p id=\"\">Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Etiam porta sem malesuada magna mollis euismod. Curabitur blandit tempus porttitor. Curabitur blandit tempus porttitor.</p>",
     "collectionId": "63020a6ad411031c64d74168",
     "coverImage": "https://uploads-ssl.webflow.com/63020a6ad41103e186d7416a/64a11cd365d155b164b5a017_hero--19.svg",
@@ -29,7 +29,7 @@
   },
   {
     "affiliation": "MyGoodPlanet",
-    "affiliationURL": "https://medium.com/@render_ghost/",
+    "affiliationURL": "https://mygoodplanet.com/",
     "body": "",
     "collectionId": "63020a6ad411031c64d74168",
     "coverImage": "https://uploads-ssl.webflow.com/63020a6ad41103e186d7416a/64a085ac08379c1910b65581_22.png",
@@ -49,7 +49,7 @@
   },
   {
     "affiliation": "Morressier",
-    "affiliationURL": "https://medium.com/@render_ghost/",
+    "affiliationURL": "https://morressier.com",
     "body": "",
     "collectionId": "63020a6ad411031c64d74168",
     "coverImage": "https://uploads-ssl.webflow.com/63020a6ad41103e186d7416a/64a11cb6c1bfe86c75f70982_hero--20.svg",
@@ -69,7 +69,7 @@
   },
   {
     "affiliation": "Morressier",
-    "affiliationURL": "https://medium.com/@render_ghost/",
+    "affiliationURL": "https://morressier.com",
     "body": "",
     "collectionId": "63020a6ad411031c64d74168",
     "coverImage": "https://uploads-ssl.webflow.com/63020a6ad41103e186d7416a/64a11cff7c06a4e2d7ca8c39_hero--27.svg",
@@ -89,7 +89,7 @@
   },
   {
     "affiliation": "LEO Pharma",
-    "affiliationURL": "https://medium.com/@render_ghost/",
+    "affiliationURL": "https://omhu.com/",
     "body": "",
     "collectionId": "63020a6ad411031c64d74168",
     "coverImage": "https://uploads-ssl.webflow.com/63020a6ad41103e186d7416a/634435bbf7d7aa6d7edaaf9b_02.svg",
@@ -109,7 +109,7 @@
   },
   {
     "affiliation": "Morressier",
-    "affiliationURL": "https://medium.com/@render_ghost/",
+    "affiliationURL": "https://morressier.com",
     "body": "",
     "collectionId": "63020a6ad411031c64d74168",
     "coverImage": "https://uploads-ssl.webflow.com/63020a6ad41103e186d7416a/64a11d0b81b40a3acc12f5f4_hero--13.svg",
@@ -129,7 +129,7 @@
   },
   {
     "affiliation": "Morressier",
-    "affiliationURL": "https://medium.com/@render_ghost/",
+    "affiliationURL": "https://morressier.com",
     "body": "<blockquote id=\"\">Curabitur blandit tempus porttitor. Donec id elit non mi porta gravida at eget metus. Donec ullamcorper nulla non metus auctor fringilla. Etiam porta sem malesuada magna mollis euismod. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper.</blockquote><p id=\"\">‍</p>",
     "collectionId": "63020a6ad411031c64d74168",
     "coverImage": "https://uploads-ssl.webflow.com/63020a6ad41103e186d7416a/64a11ce66265165d6d6150e8_hero--18.svg",

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -66,7 +66,7 @@ export default function AboutPage(): JSX.Element {
       <div className="flex flex-col items-center w-full bg-whitesmoke">
         <PageHeader />
 
-        <div className="flex flex-col gap-32 items-start w-full max-w-[1920px] px-24 pt-32 pb-128">
+        <div className="flex flex-col gap-32 items-start w-full max-w-[1920px] px-24 pt-24 gap-24 pb-128">
           <SectionHeader title="About Me" statement="How I approach complex product and service problems by bringing structure to ambiguity and using outcome-driven design to make better decisions in messy, real-world systems." />
           <SectionImage
             src="/art/portrait/art/colour.jpg"

--- a/src/pages/CareerPage.tsx
+++ b/src/pages/CareerPage.tsx
@@ -1,4 +1,5 @@
 import { BadgeLanguage } from '@/components/BadgeLanguage/BadgeLanguage';
+import { Link } from '@/components/Link/Link';
 import { PageFooter } from '@/components/PageFooter/PageFooter';
 import { PageHeader } from '@/components/PageHeader/PageHeader';
 import { SectionHeader } from '@/components/SectionHeader/SectionHeader';
@@ -52,8 +53,13 @@ export default function CareerPage(): JSX.Element {
   const { data: skillCategories, loading: skillsLoading, error: skillsError } = useSifaSkills();
   const { data: languages, loading: languagesLoading, error: languagesError } = useSifaLanguages();
 
+  const PAST_POSITIONS_LIMIT = 9;
+  const LINKEDIN_URL = 'https://linkedin.com/in/barrymprendergast';
+
   const currentPositions = positions?.filter((p) => !p.endedAt) ?? [];
-  const pastPositions = positions?.filter((p) => !!p.endedAt) ?? [];
+  const allPastPositions = positions?.filter((p) => !!p.endedAt) ?? [];
+  const pastPositions = allPastPositions.slice(0, PAST_POSITIONS_LIMIT);
+  const hasMorePastPositions = allPastPositions.length > PAST_POSITIONS_LIMIT;
 
   const loading = positionsLoading || skillsLoading || languagesLoading;
   const error = positionsError ?? skillsError ?? languagesError;
@@ -72,7 +78,7 @@ export default function CareerPage(): JSX.Element {
       <div className="flex flex-col items-center w-full bg-whitesmoke">
         <PageHeader />
 
-        <div className="flex flex-col gap-32 items-start w-full max-w-[1920px] px-24 pt-32 pb-128">
+        <div className="flex flex-col items-start w-full max-w-[1920px] px-24 pt-24 gap-24 pb-128">
           <SectionHeader title="My Career" statement="A selection of roles across startups, agencies, and enterprise organisations where I’ve helped teams deliver complex products and services in challenging, fast-moving environments." />
           {loading && <p className="font-sans font-medium text-base leading-[28px] text-black">Loading...</p>}
 
@@ -113,6 +119,9 @@ export default function CareerPage(): JSX.Element {
                   location={position.location}
                 />
               ))}
+              {hasMorePastPositions && (
+                <Link href={LINKEDIN_URL} label="View more on LinkedIn" color="blue" />
+              )}
             </>
           )}
 

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -81,7 +81,7 @@ export default function ContactPage(): JSX.Element {
       <div className="flex flex-col min-h-screen bg-whitesmoke ">
         <PageHeader />
 
-        <main className="flex flex-col flex-1 gap-32 px-24 pt-32 pb-64">
+        <main className="flex flex-col flex-1 max-w-[1920px] px-24 pt-24 gap-24 pb-128">
           <SectionHeader title="Contact Me" />
           {/* Statement */}
           <p className="font-sans font-black text-[40px] leading-[48px] sm:text-[56px] sm:leading-[64px] lg:text-[72px] lg:leading-[80px] xl:text-[96px] xl:leading-[104px] text-black max-w-[1400px]">

--- a/src/pages/PortfolioPage.tsx
+++ b/src/pages/PortfolioPage.tsx
@@ -79,7 +79,7 @@ export default function WorksPage(): JSX.Element {
       <div className='flex flex-col min-h-screen bg-whitesmoke'>
         <PageHeader />
 
-        <main className='flex flex-col items-start flex-1 gap-32 px-24 pt-32 pb-128'>
+        <main className='flex flex-col items-start flex-1 max-w-[1920px] px-24 pt-24 gap-24 pb-128'>
           <SectionHeader title='My Portfolio' statement='Case studies from across publishing, energy, government, pharma, startups, and enterprise organisations, focused on solving complex product and service problems through outcome-driven design.' />
           <CardGridCaseStudy
             cards={caseStudies.map((cs) => ({

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -119,7 +119,7 @@ export default function ProjectsPage(): JSX.Element {
       <div className="flex flex-col min-h-screen bg-whitesmoke">
         <PageHeader />
 
-        <main className="flex flex-col items-start flex-1 gap-32 px-24 pt-32 pb-128">
+        <main className='flex flex-col items-start flex-1 max-w-[1920px] px-24 pt-24 gap-24 pb-128'>
           <SectionHeader title="My Personal Projects" statement="Self-directed experiments in music, art, writing, and code, explored without briefs, deadlines, or constraints." />
           {groups.length === 0 && (
             <Paragraph size="lg">No projects found.</Paragraph>

--- a/src/pages/WritingPage.tsx
+++ b/src/pages/WritingPage.tsx
@@ -83,7 +83,7 @@ export default function WritingPage(): JSX.Element {
       <div className="flex flex-col min-h-screen bg-whitesmoke">
         <PageHeader />
 
-        <main className="flex flex-col items-start flex-1 gap-32 px-24 pt-32 pb-128">
+       <main className='flex flex-col items-start flex-1 max-w-[1920px] px-24 pt-24 gap-24 pb-128'>
           <SectionHeader title="My Writing" statement="Field notes, opinions, and reflections on UX, systems, and product design, shaped by real work with teams trying to make sense of complex problems and make better decisions." />
           {loading && <Paragraph size="lg">Loading posts...</Paragraph>}
 


### PR DESCRIPTION
## Summary

- Career page: cap past positions at 9, add 'View more on LinkedIn' link via the `Link` component
- New `Markdown` component wrapping `react-markdown` for styled prose rendering in cards
- `CardPosition` redesigned to match Figma — white/grey-06 backgrounds by role state, title + Current badge on same row, location inline in meta row
- `CardArticle`, `CardCaseStudy`, `CardProject` unified to new card design system — `aspect-[7/4]` cover image, `bg-white` wrapper, `p-32` content padding, `text-[32px] leading-[40px]` title, "Read ↗" links, removed inset border overlays
- `CardGridArticle`, `CardGridCaseStudy`, `CardGridProject` grid fix — removed `auto-rows-fr` and `h-full` so each row sizes to its own tallest card, not the tallest in the whole grid
- Added `vercel.json` rewrite rule to fix direct-URL 404s on Vercel
- Installed `react-markdown`

## Test plan

- [x] Navigate directly to `/career` — past positions capped at 9, "View more on LinkedIn" link appears
- [x] Navigate directly to `/about`, `/portfolio`, `/projects`, `/writing` — no 404
- [x] Writing page — article cards render with cover image, correct meta row, "Read ↗" link
- [x] Portfolio page — case study cards render with cover, client · type · year meta, "Read ↗" link
- [x] Projects page — project cards render with cover, badges, "View the Project ↗" link
- [x] Career page — current roles show white bg + Current badge; past roles show grey bg
- [x] No lint errors (`npm run lint`)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)